### PR TITLE
Cli mlcube timeout (#152)

### DIFF
--- a/cli/medperf/__main__.py
+++ b/cli/medperf/__main__.py
@@ -117,9 +117,19 @@ def main(
     ui: str = config.default_ui,
     host: str = config.server,
     storage: str = config.storage,
+    prepare_timeout: int = config.prepare_timeout,
+    sanity_check_timeout: int = config.sanity_check_timeout,
+    statistics_timeout: int = config.statistics_timeout,
+    infer_timeout: int = config.infer_timeout,
+    evaluate_timeout: int = config.evaluate_timeout,
 ):
     # Set configuration variables
     config.storage = abspath(expanduser(storage))
+    config.prepare_timeout = prepare_timeout
+    config.sanity_check_timeout = sanity_check_timeout
+    config.statistics_timeout = statistics_timeout
+    config.infer_timeout = infer_timeout
+    config.evaluate_timeout = evaluate_timeout
     if log_file is None:
         log_file = storage_path(config.log_file)
     else:

--- a/cli/medperf/commands/dataset/create.py
+++ b/cli/medperf/commands/dataset/create.py
@@ -81,6 +81,9 @@ class DataPreparation:
         check_cube_validity(self.cube, self.ui)
 
     def run_cube_tasks(self):
+        prepare_timeout = config.prepare_timeout
+        sanity_check_timeout = config.sanity_check_timeout
+        statistics_timeout = config.statistics_timeout
         data_path = self.data_path
         labels_path = self.labels_path
         out_datapath = self.out_datapath
@@ -89,6 +92,7 @@ class DataPreparation:
         self.cube.run(
             self.ui,
             task="prepare",
+            timeout=prepare_timeout,
             data_path=data_path,
             labels_path=labels_path,
             output_path=out_datapath,
@@ -96,11 +100,21 @@ class DataPreparation:
         self.ui.print("> Cube execution complete")
 
         self.ui.text = "Running sanity check..."
-        self.cube.run(self.ui, task="sanity_check", data_path=out_datapath)
+        self.cube.run(
+            self.ui,
+            task="sanity_check",
+            timeout=sanity_check_timeout,
+            data_path=out_datapath,
+        )
         self.ui.print("> Sanity checks complete")
 
         self.ui.text = "Generating statistics..."
-        self.cube.run(self.ui, task="statistics", data_path=out_datapath)
+        self.cube.run(
+            self.ui,
+            task="statistics",
+            timeout=statistics_timeout,
+            data_path=out_datapath,
+        )
         self.ui.print("> Statistics complete")
 
     def create_registration(self):

--- a/cli/medperf/commands/result/create.py
+++ b/cli/medperf/commands/result/create.py
@@ -95,6 +95,8 @@ class BenchmarkExecution:
         return cube
 
     def run_cubes(self):
+        infer_timeout = config.infer_timeout
+        evaluate_timeout = config.evaluate_timeout
         self.ui.text = "Running model inference on dataset"
         model_uid = str(self.model_cube.uid)
         data_uid = str(self.dataset.data_uid)
@@ -102,7 +104,11 @@ class BenchmarkExecution:
         preds_path = storage_path(preds_path)
         data_path = self.dataset.data_path
         self.model_cube.run(
-            self.ui, task="infer", data_path=data_path, output_path=preds_path
+            self.ui,
+            task="infer",
+            timeout=infer_timeout,
+            data_path=data_path,
+            output_path=preds_path,
         )
         self.ui.print("> Model execution complete")
 
@@ -113,6 +119,7 @@ class BenchmarkExecution:
         self.evaluator.run(
             self.ui,
             task="evaluate",
+            timeout=evaluate_timeout,
             predictions=preds_path,
             labels=labels_path,
             output_path=out_path,

--- a/cli/medperf/config.py
+++ b/cli/medperf/config.py
@@ -30,3 +30,9 @@ default_ui = "CLI"
 git_file_domain = "https://raw.githubusercontent.com"
 comms = None
 ui = None
+
+prepare_timeout = None
+sanity_check_timeout = None
+statistics_timeout = None
+infer_timeout = None
+evaluate_timeout = None

--- a/cli/medperf/entities/cube.py
+++ b/cli/medperf/entities/cube.py
@@ -135,12 +135,13 @@ class Cube(object):
             valid_additional = True
         return valid_additional
 
-    def run(self, ui: UI, task: str, **kwargs):
+    def run(self, ui: UI, task: str, timeout: int = None, **kwargs):
         """Executes a given task on the cube instance
 
         Args:
             ui (UI): an instance of an UI implementation
             task (str): task to run
+            timeout (int, optional): timeout for the task in seconds. Defaults to None.
             kwargs (dict): additional arguments that are passed directly to the mlcube command
         """
         cmd = f"mlcube run --mlcube={self.cube_path} --task={task}"
@@ -148,7 +149,7 @@ class Cube(object):
             cmd_arg = f"{k}={v}"
             cmd = " ".join([cmd, cmd_arg])
         logging.info(f"Running MLCube command: {cmd}")
-        proc = pexpect.spawn(cmd, timeout=None)
+        proc = pexpect.spawn(cmd, timeout=timeout)
         proc_out = combine_proc_sp_text(proc, ui)
         proc.close()
         logging.debug(proc_out)

--- a/cli/medperf/tests/commands/dataset/test_create.py
+++ b/cli/medperf/tests/commands/dataset/test_create.py
@@ -84,12 +84,13 @@ class TestWithDefaultUID:
         prepare = call(
             ui,
             task="prepare",
+            timeout=None,
             data_path=DATA_PATH,
             labels_path=LABELS_PATH,
             output_path=OUT_DATAPATH,
         )
-        check = call(ui, task="sanity_check", data_path=OUT_DATAPATH)
-        stats = call(ui, task="statistics", data_path=OUT_DATAPATH)
+        check = call(ui, task="sanity_check", data_path=OUT_DATAPATH, timeout=None)
+        stats = call(ui, task="statistics", data_path=OUT_DATAPATH, timeout=None)
         calls = [prepare, check, stats]
 
         # Act

--- a/cli/medperf/tests/entities/test_cube.py
+++ b/cli/medperf/tests/entities/test_cube.py
@@ -312,7 +312,10 @@ def test_cube_is_invalid_with_incorrect_hash(mocker, comms, tar_body, no_local):
     assert not cube.is_valid()
 
 
-def test_cube_runs_command_with_pexpect(mocker, ui, comms, basic_body, no_local):
+@pytest.mark.parametrize("timeout", rand_l(1, 100, 1) + [None])
+def test_cube_runs_command_with_pexpect(
+    mocker, ui, comms, basic_body, no_local, timeout
+):
     # Arrange
     mpexpect = MockPexpect(0)
     mocker.patch(PATCH_CUBE.format("pexpect.spawn"), side_effect=mpexpect.spawn)
@@ -324,10 +327,10 @@ def test_cube_runs_command_with_pexpect(mocker, ui, comms, basic_body, no_local)
     # Act
     uid = 1
     cube = Cube.get(uid, comms, ui)
-    cube.run(ui, "task")
+    cube.run(ui, "task", timeout=timeout)
 
     # Assert
-    spy.assert_called_once_with(expected_cmd, timeout=None)
+    spy.assert_called_once_with(expected_cmd, timeout=timeout)
 
 
 def test_cube_runs_command_with_extra_args(mocker, ui, comms, basic_body, no_local):

--- a/cli/medperf/utils.py
+++ b/cli/medperf/utils.py
@@ -13,6 +13,7 @@ from pexpect import spawn
 from datetime import datetime
 from typing import List, Tuple
 from colorama import Fore, Style
+from pexpect.exceptions import TIMEOUT
 
 import medperf.config as config
 from medperf.ui.interface import UI
@@ -290,7 +291,12 @@ def combine_proc_sp_text(proc: spawn, ui: "UI") -> str:
     static_text = ui.text
     proc_out = ""
     while proc.isalive():
-        line = byte = proc.read(1)
+        try:
+            line = byte = proc.read(1)
+        except TIMEOUT:
+            logging.info("Process timed out")
+            pretty_error("Process timed out", ui)
+
         while byte and not re.match(b"[\r\n]", byte):
             byte = proc.read(1)
             line += byte


### PR DESCRIPTION
* Add optional timeouts to all mlcube executions

* Fix/Add timeout testing

* Reformat code
* 
This PR adds functionality for specifying timeouts for each task independently. Closes #140 