### PR TITLE
Add support for different MLCube platforms

### DIFF
--- a/cli/medperf/__main__.py
+++ b/cli/medperf/__main__.py
@@ -108,9 +108,11 @@ def main(
     ui: str = config.default_ui,
     host: str = config.server,
     storage: str = config.storage,
+    platform: str = config.platform,
 ):
     # Set configuration variables
     config.storage = abspath(expanduser(storage))
+    config.platform = platform
     if log_file is None:
         log_file = storage_path(config.log_file)
     else:

--- a/cli/medperf/config.py
+++ b/cli/medperf/config.py
@@ -27,6 +27,7 @@ test_dset_prefix = "test_"
 demo_dset_paths_file = "paths.yaml"
 default_comms = "REST"
 default_ui = "CLI"
+platform = "docker"
 git_file_domain = "https://raw.githubusercontent.com"
 comms = None
 ui = None

--- a/cli/medperf/entities/cube.py
+++ b/cli/medperf/entities/cube.py
@@ -143,7 +143,7 @@ class Cube(object):
             task (str): task to run
             kwargs (dict): additional arguments that are passed directly to the mlcube command
         """
-        cmd = f"mlcube run --mlcube={self.cube_path} --task={task}"
+        cmd = f"mlcube run --mlcube={self.cube_path} --task={task} --platform={config.platform}"
         for k, v in kwargs.items():
             cmd_arg = f"{k}={v}"
             cmd = " ".join([cmd, cmd_arg])


### PR DESCRIPTION
This PR adds support to different MLCube platforms through the `--platform` parameter. This parameter is then passed to the respective mlcubes.