### PR TITLE
Hash checking for cached mlcubes

### DIFF
--- a/cli/medperf/commands/compatibility_test.py
+++ b/cli/medperf/commands/compatibility_test.py
@@ -174,6 +174,16 @@ class CompatibilityTestExecution:
             dst = os.path.join(cubes_storage, temp_uid)
             os.symlink(path, dst)
             logging.info(f"local cube will be linked to path: {dst}")
+            cube_metadata_file = os.path.join(path, config.cube_metadata_filename)
+            cube_hashes_filename = os.path.join(path, config.cube_hashes_filename)
+            if not os.path.exists(cube_metadata_file):
+                metadata = {"name": temp_uid, "is_valid": True}
+                with open(cube_metadata_file, "w") as f:
+                    yaml.dump(metadata, f)
+            if not os.path.exists(cube_hashes_filename):
+                hashes = {"additional_files_tarball_hash": "", "image_tarball_hash": ""}
+                with open(cube_hashes_filename, "w") as f:
+                    yaml.dump(hashes, f)
             return
 
         logging.warning(f"mlcube {val} was not found as an existing mlcube")

--- a/cli/medperf/config.py
+++ b/cli/medperf/config.py
@@ -35,6 +35,7 @@ cube_submission_id = "tmp_submission"
 test_dset_prefix = "test_"
 demo_dset_paths_file = "paths.yaml"
 cube_metadata_filename = "mlcube-meta.yaml"
+cube_hashes_filename = "mlcube-hashes.yaml"
 
 default_comms = "REST"
 default_ui = "CLI"

--- a/cli/medperf/config.py
+++ b/cli/medperf/config.py
@@ -34,6 +34,7 @@ test_cube_prefix = "test_"
 cube_submission_id = "tmp_submission"
 test_dset_prefix = "test_"
 demo_dset_paths_file = "paths.yaml"
+cube_metadata_filename = "mlcube-meta.yaml"
 
 default_comms = "REST"
 default_ui = "CLI"

--- a/cli/medperf/entities/cube.py
+++ b/cli/medperf/entities/cube.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 from medperf.utils import (
     approval_prompt,
+    save_cube_metadata,
     get_file_sha1,
     pretty_error,
     untar,
@@ -78,13 +79,19 @@ class Cube(object):
         cubes = []
         for uid in uids:
             cube_path = os.path.join(cubes_storage, uid, config.cube_filename)
-            with open(cube_path, "r") as f:
+            meta_file = os.path.join(cubes_storage, uid, config.cube_metadata_filename)
+            with open(meta_file, "r") as f:
                 meta = yaml.safe_load(f)
 
             params_path = os.path.join(cubes_storage, uid, config.params_filename)
             if not os.path.exists(params_path):
                 params_path = None
-            cube = cls(uid, meta, cube_path, params_path)
+
+            additional_hash = meta.get("computed_additional_files_tarball_hash", "")
+            image_tarball_hash = meta.get("computed_image_tarball_hash", "")
+            cube = cls(
+                uid, meta, cube_path, params_path, additional_hash, image_tarball_hash
+            )
             cubes.append(cube)
 
         return cubes
@@ -131,6 +138,13 @@ class Cube(object):
             image_tarball_hash = get_file_sha1(image_path)
             untar(image_path)
 
+        meta["computed_additional_files_tarball_hash"] = (
+            additional_hash if additional_hash else ""
+        )
+        meta["computed_image_tarball_hash"] = (
+            image_tarball_hash if image_tarball_hash else ""
+        )
+        save_cube_metadata(meta)
         return cls(
             cube_uid, meta, cube_path, params_path, additional_hash, image_tarball_hash
         )

--- a/cli/medperf/entities/cube.py
+++ b/cli/medperf/entities/cube.py
@@ -87,8 +87,12 @@ class Cube(object):
             if not os.path.exists(params_path):
                 params_path = None
 
-            additional_hash = meta.get("computed_additional_files_tarball_hash", "")
-            image_tarball_hash = meta.get("computed_image_tarball_hash", "")
+            local_hashes_file = os.path.join(cubes_storage, uid, config.cube_hashes_filename)
+            with open(local_hashes_file, "r") as f:
+                local_hashes = yaml.safe_load(f)
+            additional_hash = local_hashes["additional_files_tarball_hash"]
+            image_tarball_hash = local_hashes["image_tarball_hash"]
+
             cube = cls(
                 uid, meta, cube_path, params_path, additional_hash, image_tarball_hash
             )
@@ -138,13 +142,11 @@ class Cube(object):
             image_tarball_hash = get_file_sha1(image_path)
             untar(image_path)
 
-        meta["computed_additional_files_tarball_hash"] = (
-            additional_hash if additional_hash else ""
-        )
-        meta["computed_image_tarball_hash"] = (
-            image_tarball_hash if image_tarball_hash else ""
-        )
-        save_cube_metadata(meta)
+        local_hashes = {
+            "additional_files_tarball_hash": additional_hash if additional_hash else "",
+            "image_tarball_hash": image_tarball_hash if image_tarball_hash else ""
+        }
+        save_cube_metadata(meta, local_hashes)
         return cls(
             cube_uid, meta, cube_path, params_path, additional_hash, image_tarball_hash
         )

--- a/cli/medperf/tests/commands/test_compatibility_test.py
+++ b/cli/medperf/tests/commands/test_compatibility_test.py
@@ -478,15 +478,21 @@ def test_custom_cubes_metadata_files_creation(mocker, comms, ui, files_already_e
     # Arrange
     model_path = "/path/to/model"
     if files_already_exist:
-        exists_side_effect = lambda path: True
+
+        def exists_side_effect(path):
+            return True
+
         num_calls_expected = 0
     else:
         cube_metadata_file = os.path.join(model_path, config.cube_metadata_filename)
         cube_hashes_filename = os.path.join(model_path, config.cube_hashes_filename)
-        exists_side_effect = lambda path: path not in [
-            cube_metadata_file,
-            cube_hashes_filename,
-        ]
+
+        def exists_side_effect(path):
+            return path not in [
+                cube_metadata_file,
+                cube_hashes_filename,
+            ]
+
         num_calls_expected = 2
 
     mocker.patch("os.symlink")

--- a/cli/medperf/tests/test_utils.py
+++ b/cli/medperf/tests/test_utils.py
@@ -9,9 +9,9 @@ from unittest.mock import mock_open, call, ANY
 from medperf import utils
 from medperf.ui.interface import UI
 import medperf.config as config
-from medperf.tests.utils import rand_l
+from medperf.tests.utils import rand_l, cube_local_hashes_generator
 from medperf.tests.mocks import MockCube, MockTar
-
+from medperf.tests.mocks.requests import cube_metadata_generator
 
 parent = config.storage
 data = utils.storage_path(config.data_storage)
@@ -413,3 +413,28 @@ def test__results_path_returns_expected_path(bmk, model, gen_uid):
 
     # Assert
     assert path == expected_path
+
+
+@pytest.mark.parametrize("cube_uid", rand_l(1, 500, 3))
+def test_save_cube_metadata_saves_as_expected(mocker, cube_uid):
+    # Arrange
+    cube_uid = str(cube_uid)
+    meta = cube_metadata_generator()(cube_uid)
+    hashes = cube_local_hashes_generator()
+    cubes_path = utils.storage_path(config.cubes_storage)
+    meta_path = os.path.join(cubes_path, cube_uid, config.cube_metadata_filename)
+    hashes_path = os.path.join(cubes_path, cube_uid, config.cube_hashes_filename)
+
+    mocker.patch("os.path.isdir", return_value=True)
+    meta_handler = mock_open().return_value
+    hash_handler = mock_open().return_value
+    open_spy = mocker.patch("builtins.open", side_effect=[meta_handler, hash_handler])
+    yaml_spy = mocker.patch("yaml.dump")
+
+    # Act
+    utils.save_cube_metadata(meta, hashes)
+
+    # Assert
+    open_spy.assert_has_calls([call(meta_path, "w"), call(hashes_path, "w")])
+    assert open_spy.call_count == 2
+    yaml_spy.assert_has_calls([call(meta, meta_handler), call(hashes, hash_handler)])

--- a/cli/medperf/tests/utils.py
+++ b/cli/medperf/tests/utils.py
@@ -3,3 +3,19 @@ import random
 
 def rand_l(a, b, size):
     return random.sample(range(a, b), size)
+
+
+def cube_local_hashes_generator(valid=True, with_tarball=True, with_image=True):
+    local_hashes = {"additional_files_tarball_hash": "", "image_tarball_hash": ""}
+
+    if with_tarball:
+        local_hashes["additional_files_tarball_hash"] = (
+            "additional_files_tarball_hash" if valid else "incorrect_hash"
+        )
+
+    if with_image:
+        local_hashes["image_tarball_hash"] = (
+            "image_tarball_hash" if valid else "incorrect_hash"
+        )
+
+    return local_hashes

--- a/cli/medperf/utils.py
+++ b/cli/medperf/utils.py
@@ -253,7 +253,7 @@ def check_cube_validity(cube: "Cube", ui: "UI"):
     logging.info(f"Checking cube {cube.name} validity")
     ui.text = "Checking cube MD5 hash..."
     if not cube.is_valid():
-        pretty_error("MD5 hash doesn't match")
+        pretty_error("MD5 hash doesn't match", ui)
     logging.info(f"Cube {cube.name} is valid")
     ui.print(f"> {cube.name} MD5 hash check complete")
 

--- a/cli/medperf/utils.py
+++ b/cli/medperf/utils.py
@@ -436,10 +436,13 @@ def list_files(startpath):
     return tree_str
 
 
-def save_cube_metadata(meta):
+def save_cube_metadata(meta, local_hashes):
     c_path = cube_path(meta["id"])
     if not os.path.isdir(c_path):
         os.makedirs(c_path, exist_ok=True)
     meta_file = os.path.join(c_path, config.cube_metadata_filename)
     with open(meta_file, "w") as f:
         yaml.dump(meta, f)
+    local_hashes_file = os.path.join(c_path, config.cube_hashes_filename)
+    with open(local_hashes_file, "w") as f:
+        yaml.dump(local_hashes, f)

--- a/cli/medperf/utils.py
+++ b/cli/medperf/utils.py
@@ -434,3 +434,12 @@ def list_files(startpath):
             tree_str += "{}{}\n".format(subindent, f)
 
     return tree_str
+
+
+def save_cube_metadata(meta):
+    c_path = cube_path(meta["id"])
+    if not os.path.isdir(c_path):
+        os.makedirs(c_path, exist_ok=True)
+    meta_file = os.path.join(c_path, config.cube_metadata_filename)
+    with open(meta_file, "w") as f:
+        yaml.dump(meta, f)


### PR DESCRIPTION
This PR allows to perform hash check of a cached MLCube each time it is retrieved from local storage. This will be done by comparing server hashes and locally computed hashes which are cached during the MLCube retrieval.

Closes #202 
