### PR TITLE
Invalid MLCube Check

### DIFF
--- a/cli/medperf/entities/cube.py
+++ b/cli/medperf/entities/cube.py
@@ -99,6 +99,7 @@ class Cube(object):
         """
         add_files = "additional_files_tarball_url"
         add_hash = "additional_files_tarball_hash"
+        valid_cube = self.meta["is_valid"]
         has_additional = add_files in self.meta and self.meta[add_files]
         if has_additional:
             valid_additional = self.additional_hash == self.meta[add_hash]
@@ -110,7 +111,7 @@ class Cube(object):
             valid_image = self.image_tarball_hash == self.meta["image_tarball_hash"]
         else:
             valid_image = True
-        return valid_additional and valid_image
+        return valid_cube and valid_additional and valid_image
 
     def run(self, ui: UI, task: str, **kwargs):
         """Executes a given task on the cube instance

--- a/cli/medperf/tests/entities/test_cube.py
+++ b/cli/medperf/tests/entities/test_cube.py
@@ -226,6 +226,16 @@ def test_cube_is_valid_with_correct_image_tarball_hash(mocker, comms, img_body):
     assert cube.is_valid()
 
 
+def test_cube_is_invalid_if_invalidated(mocker, comms, basic_body):
+    # Arrange
+    uid = 1
+    cube = Cube.get(uid, comms)
+    cube.meta["is_valid"] = False
+
+    # Act & Assert
+    assert not cube.is_valid()
+
+
 def test_cube_is_invalid_with_incorrect_tarball_hash(mocker, comms, tar_body):
     # Arrange
     mocker.patch(PATCH_CUBE.format("get_file_sha1"), return_value="incorrect_hash")

--- a/cli/medperf/tests/mocks/requests.py
+++ b/cli/medperf/tests/mocks/requests.py
@@ -61,6 +61,7 @@ def cube_metadata_generator(with_params=False, with_tarball=False, with_image=Fa
             "created_at": "timestamp",
             "modified_at": "timestamp",
             "owner": 1,
+            "is_valid": True,
         }
 
     return cube_metadata_body


### PR DESCRIPTION
This PR adds a check for the `is_valid` field before execution. This ensures that MLCubes that have been marked invalid won't be executed by the platform. Closes #29.