### PR TITLE
Pass metadata through the generated_metadata key

### DIFF
--- a/cli/medperf/entities/dataset.py
+++ b/cli/medperf/entities/dataset.py
@@ -50,7 +50,11 @@ class Dataset:
         self.input_data_hash = registration["input_data_hash"]
         self.separate_labels = registration.get("separate_labels", False)
         self.split_seed = registration["split_seed"]
-        self.generated_metadata = registration["metadata"]
+        if "metadata" in registration:
+            # Make sure it is backwards-compatible
+            self.generated_metadata = registration["metadata"]
+        else:
+            self.generated_metadata = registration["generated_metadata"]
         self.status = registration["status"]
         self.state = registration["state"]
 

--- a/cli/medperf/entities/dataset.py
+++ b/cli/medperf/entities/dataset.py
@@ -50,7 +50,7 @@ class Dataset:
         self.input_data_hash = registration["input_data_hash"]
         self.separate_labels = registration.get("separate_labels", False)
         self.split_seed = registration["split_seed"]
-        self.metadata = registration["metadata"]
+        self.generated_metadata = registration["metadata"]
         self.status = registration["status"]
         self.state = registration["state"]
 
@@ -69,7 +69,7 @@ class Dataset:
             "input_data_hash": self.input_data_hash,
             "generated_uid": self.generated_uid,
             "split_seed": self.split_seed,
-            "metadata": self.metadata,
+            "generated_metadata": self.generated_metadata,
             "status": self.status,
             "state": self.state,
             "separate_labels": self.separate_labels,

--- a/cli/medperf/entities/registration.py
+++ b/cli/medperf/entities/registration.py
@@ -93,7 +93,7 @@ class Registration:
             "data_preparation_mlcube": self.cube.uid,
             "generated_uid": self.generated_uid,
             "input_data_hash": self.in_uid,
-            "metadata": self.stats,
+            "generated_metadata": self.stats,
             "status": self.status,
             "uid": self.uid,
             "state": "OPERATION",

--- a/cli/medperf/tests/entities/test_dataset.py
+++ b/cli/medperf/tests/entities/test_dataset.py
@@ -14,7 +14,7 @@ REGISTRATION_MOCK = {
     "location": "location",
     "data_preparation_mlcube": "data_preparation_mlcube",
     "split_seed": "split_seed",
-    "metadata": {},
+    "metadata": {"metadata_key": "metadata_value"},
     "generated_uid": "generated_uid",
     "input_data_hash": "input_data_hash",
     "status": "status",
@@ -110,6 +110,18 @@ def test_all_ignores_temporary_datasets(mocker, ui, all_uids):
 
     # Assert
     assert f"{TMP_PREFIX}3" not in uids
+
+
+@pytest.mark.parametrize("all_uids", [["1", "2", f"{TMP_PREFIX}3"]], indirect=True)
+def test_dataset_metadata_is_backwards_compatible(mocker, ui, all_uids):
+    # Arrange
+    uid = "1"
+
+    # Act
+    dset = Dataset(uid, ui)
+
+    # Assert
+    assert dset.generated_metadata == REGISTRATION_MOCK["metadata"]
 
 
 @pytest.mark.parametrize(

--- a/cli/medperf/tests/entities/test_registration.py
+++ b/cli/medperf/tests/entities/test_registration.py
@@ -22,7 +22,7 @@ REG_DICT_KEYS = [
     "data_preparation_mlcube",
     "generated_uid",
     "input_data_hash",
-    "metadata",
+    "generated_metadata",
     "status",
     "uid",
     "state",


### PR DESCRIPTION
This PR fixes the issue where the dataset statistics were not being stored in the server because of key mismatch. Closes #210 