### PR TITLE
Fix benchmark associate with no entities

### DIFF
--- a/cli/medperf/commands/benchmark/associate.py
+++ b/cli/medperf/commands/benchmark/associate.py
@@ -26,10 +26,11 @@ class AssociateBenchmark:
             ui (UI): Instance of UI interface
             approved (bool): Skip approval step. Defaults to False
         """
-        if model_uid and data_uid:
+        too_many_resources = data_uid and model_uid
+        no_resource = data_uid is None and model_uid is None
+        if no_resource or too_many_resources:
             pretty_error(
-                "Can only associate one entity at a time. Pass a model or a dataset only",
-                ui,
+                "Invalid arguments. Must provide either a dataset or mlcube", ui
             )
         if model_uid is not None:
             AssociateCube.run(model_uid, benchmark_uid, comms, ui, approved=approved)

--- a/cli/medperf/tests/commands/benchmark/test_associate.py
+++ b/cli/medperf/tests/commands/benchmark/test_associate.py
@@ -10,6 +10,7 @@ PATCH_ASSOC = "medperf.commands.benchmark.associate.{}"
 @pytest.mark.parametrize("data_uid", [None, "1"])
 def test_run_fails_if_model_and_dset_passed(mocker, model_uid, data_uid, comms, ui):
     # Arrange
+    num_arguments = int(data_uid is None) + int(model_uid is None)
     spy = mocker.patch(PATCH_ASSOC.format("pretty_error"))
     mocker.patch.object(comms, "associate_cube")
     mocker.patch.object(comms, "associate_dset")
@@ -20,7 +21,7 @@ def test_run_fails_if_model_and_dset_passed(mocker, model_uid, data_uid, comms, 
     AssociateBenchmark.run("1", model_uid, data_uid, comms, ui)
 
     # Assert
-    if model_uid and data_uid:
+    if num_arguments != 1:
         spy.assert_called_once()
     else:
         spy.assert_not_called()


### PR DESCRIPTION
This PR prevent `medperf benchmark associate` command to be run without providing neither a model nor a dataset.
Closes #214 
