### PR TITLE
use enums for approval status

### DIFF
--- a/cli/medperf/commands/association/approval.py
+++ b/cli/medperf/commands/association/approval.py
@@ -32,10 +32,10 @@ class Approval:
 
         if dataset_uid:
             comms.set_dataset_association_approval(
-                benchmark_uid, dataset_uid, approval_status
+                benchmark_uid, dataset_uid, approval_status.value
             )
 
         if mlcube_uid:
             comms.set_mlcube_association_approval(
-                benchmark_uid, mlcube_uid, approval_status
+                benchmark_uid, mlcube_uid, approval_status.value
             )

--- a/cli/medperf/commands/association/association.py
+++ b/cli/medperf/commands/association/association.py
@@ -5,6 +5,7 @@ import medperf.config as config
 from medperf.decorators import clean_except
 from medperf.commands.association.list import ListAssociations
 from medperf.commands.association.approval import Approval
+from medperf.enums import Status
 
 app = typer.Typer()
 
@@ -39,7 +40,7 @@ def approve(
     """
     comms = config.comms
     ui = config.ui
-    Approval.run(benchmark_uid, "APPROVED", comms, ui, dataset_uid, mlcube_uid)
+    Approval.run(benchmark_uid, Status.APPROVED, comms, ui, dataset_uid, mlcube_uid)
     ui.print("✅ Done!")
 
 
@@ -59,5 +60,5 @@ def reject(
     """
     comms = config.comms
     ui = config.ui
-    Approval.run(benchmark_uid, "REJECTED", comms, ui, dataset_uid, mlcube_uid)
+    Approval.run(benchmark_uid, Status.REJECTED, comms, ui, dataset_uid, mlcube_uid)
     ui.print("✅ Done!")

--- a/cli/medperf/commands/benchmark/submit.py
+++ b/cli/medperf/commands/benchmark/submit.py
@@ -1,4 +1,5 @@
 import logging
+from medperf.enums import Status
 import validators
 
 from medperf.ui.interface import UI
@@ -154,7 +155,7 @@ class SubmitBenchmark:
             "data_evaluator_mlcube": int(self.data_evaluator_mlcube),
             "state": "OPERATION",
             "is_valid": True,
-            "approval_status": "PENDING",
+            "approval_status": Status.PENDING.value,
             "metadata": {"results": self.results.todict()},
         }
 

--- a/cli/medperf/comms/rest.py
+++ b/cli/medperf/comms/rest.py
@@ -3,7 +3,7 @@ import requests
 import logging
 import os
 
-from medperf.enums import Role
+from medperf.enums import Role, Status
 import medperf.config as config
 from medperf.ui.interface import UI
 from medperf.comms.interface import Comms
@@ -467,7 +467,7 @@ class REST(Comms):
         data = {
             "dataset": data_uid,
             "benchmark": benchmark_uid,
-            "approval_status": "PENDING",
+            "approval_status": Status.PENDING.value,
             "metadata": metadata,
         }
         res = self.__auth_post(f"{self.server_url}/datasets/benchmarks/", json=data)
@@ -485,7 +485,7 @@ class REST(Comms):
         """
         data = {
             "results": {},
-            "approval_status": "PENDING",
+            "approval_status": Status.PENDING.value,
             "model_mlcube": cube_uid,
             "benchmark": benchmark_uid,
             "metadata": metadata,

--- a/cli/medperf/entities/dataset.py
+++ b/cli/medperf/entities/dataset.py
@@ -1,4 +1,5 @@
 import os
+from medperf.enums import Status
 import yaml
 import logging
 from typing import List
@@ -55,7 +56,7 @@ class Dataset:
             self.generated_metadata = registration["metadata"]
         else:
             self.generated_metadata = registration["generated_metadata"]
-        self.status = registration["status"]
+        self.status = Status(registration["status"])
         self.state = registration["state"]
 
         self.labels_path = self.data_path
@@ -74,7 +75,7 @@ class Dataset:
             "generated_uid": self.generated_uid,
             "split_seed": self.split_seed,
             "generated_metadata": self.generated_metadata,
-            "status": self.status,
+            "status": self.status.value,
             "state": self.state,
             "separate_labels": self.separate_labels,
         }
@@ -166,7 +167,7 @@ class Dataset:
         Returns:
             bool: Wether the user gave consent or not.
         """
-        if self.status != "PENDING":
+        if self.status != Status.PENDING:
             return True
 
         dict_pretty_print(self.registration, ui)
@@ -178,9 +179,9 @@ class Dataset:
             ui,
         )
         if approved:
-            self.status = "APPROVED"
+            self.status = Status.APPROVED
         else:
-            self.status = "REJECTED"
+            self.status = Status.REJECTED
         return approved
 
     def upload(self, comms: Comms):

--- a/cli/medperf/entities/registration.py
+++ b/cli/medperf/entities/registration.py
@@ -1,4 +1,5 @@
 import os
+from medperf.enums import Status
 import yaml
 from pathlib import Path
 
@@ -48,7 +49,7 @@ class Registration:
         self.description = description
         self.split_seed = 0
         self.location = location
-        self.status = "PENDING"
+        self.status = Status.PENDING
         self.generated_uid = None
         self.uid = None
         self.in_uid = None
@@ -95,7 +96,7 @@ class Registration:
             "generated_uid": self.generated_uid,
             "input_data_hash": self.in_uid,
             "generated_metadata": self.stats,
-            "status": self.status,
+            "status": self.status.value,
             "uid": self.uid,
             "state": "OPERATION",
             "separate_labels": self.separate_labels,
@@ -109,7 +110,7 @@ class Registration:
         Returns:
             bool: Wether the user gave consent or not.
         """
-        if self.status == "APPROVED":
+        if self.status == Status.APPROVED:
             return True
 
         dict_pretty_print(self.todict(), ui)

--- a/cli/medperf/entities/result.py
+++ b/cli/medperf/entities/result.py
@@ -1,4 +1,5 @@
 import os
+from medperf.enums import Status
 import yaml
 import logging
 from typing import List
@@ -40,7 +41,7 @@ class Result:
         self.benchmark_uid = benchmark_uid
         self.dataset_uid = dataset_uid
         self.model_uid = model_uid
-        self.status = "PENDING"
+        self.status = Status.PENDING
         self.results = {}
         self.get_results()
         self.uid = self.results.get("uid", None)
@@ -67,7 +68,7 @@ class Result:
             "name": f"{self.benchmark_uid}_{self.model_uid}_{self.dataset_uid}",
             "results": results,
             "metadata": {},
-            "approval_status": self.status,
+            "approval_status": self.status.value,
             "benchmark": self.benchmark_uid,
             "model": self.model_uid,
             "dataset": self.dataset_uid,
@@ -80,7 +81,7 @@ class Result:
         Returns:
             bool: Wether the user gave consent or not
         """
-        if self.status == "APPROVED":
+        if self.status == Status.APPROVED:
             return True
 
         dict_pretty_print(self.todict(), ui)

--- a/cli/medperf/tests/commands/association/test_approve.py
+++ b/cli/medperf/tests/commands/association/test_approve.py
@@ -1,3 +1,4 @@
+from medperf.enums import Status
 import pytest
 
 from medperf.tests.utils import rand_l
@@ -19,9 +20,9 @@ def test_run_fails_if_invalid_arguments(mocker, comms, ui, dset_uid, mlcube_uid)
     # Act & Assert
     if num_arguments != 1:
         with pytest.raises(SystemExit):
-            Approval.run("1", "APPROVE", comms, ui, dset_uid, mlcube_uid)
+            Approval.run("1", Status.APPROVED, comms, ui, dset_uid, mlcube_uid)
     else:
-        Approval.run("1", "APPROVE", comms, ui, dset_uid, mlcube_uid)
+        Approval.run("1", Status.APPROVED, comms, ui, dset_uid, mlcube_uid)
 
     # Assert
     if num_arguments == 1:
@@ -29,7 +30,7 @@ def test_run_fails_if_invalid_arguments(mocker, comms, ui, dset_uid, mlcube_uid)
 
 
 @pytest.mark.parametrize("dset_uid", rand_l(1, 500, 2))
-@pytest.mark.parametrize("status", ["APPROVED", "REJECTED"])
+@pytest.mark.parametrize("status", [Status.APPROVED, Status.REJECTED])
 def test_run_calls_comms_dset_approval_with_status(mocker, comms, ui, dset_uid, status):
     # Arrange
     spy = mocker.patch.object(comms, "set_dataset_association_approval")
@@ -38,11 +39,11 @@ def test_run_calls_comms_dset_approval_with_status(mocker, comms, ui, dset_uid, 
     Approval.run("1", status, comms, ui, dataset_uid=dset_uid)
 
     # Assert
-    spy.assert_called_once_with("1", dset_uid, status)
+    spy.assert_called_once_with("1", dset_uid, status.value)
 
 
 @pytest.mark.parametrize("mlcube_uid", rand_l(1, 500, 2))
-@pytest.mark.parametrize("status", ["APPROVED", "REJECTED"])
+@pytest.mark.parametrize("status", [Status.APPROVED, Status.REJECTED])
 def test_run_calls_comms_mlcube_approval_with_status(
     mocker, comms, ui, mlcube_uid, status
 ):
@@ -53,4 +54,4 @@ def test_run_calls_comms_mlcube_approval_with_status(
     Approval.run("1", status, comms, ui, mlcube_uid=mlcube_uid)
 
     # Assert
-    spy.assert_called_once_with("1", mlcube_uid, status)
+    spy.assert_called_once_with("1", mlcube_uid, status.value)

--- a/cli/medperf/tests/commands/association/test_list.py
+++ b/cli/medperf/tests/commands/association/test_list.py
@@ -1,3 +1,4 @@
+from medperf.enums import Status
 import pytest
 
 from medperf.commands.association.list import ListAssociations
@@ -22,12 +23,17 @@ def test_run_gets_dset_and_cube_associations(mocker, comms, ui):
 def test_run_filters_associations_by_filter(mocker, comms, ui, filter):
     # Arrange
     dset_assocs = [
-        {"dataset": 1, "benchmark": 1, "initiated_by": 1, "approval_status": "PENDING"},
+        {
+            "dataset": 1,
+            "benchmark": 1,
+            "initiated_by": 1,
+            "approval_status": Status.PENDING.value,
+        },
         {
             "dataset": 2,
             "benchmark": 1,
             "initiated_by": 1,
-            "approval_status": "APPROVED",
+            "approval_status": Status.APPROVED.value,
         },
     ]
     cube_assocs = [
@@ -35,7 +41,7 @@ def test_run_filters_associations_by_filter(mocker, comms, ui, filter):
             "model_mlcube": 1,
             "benchmark": 1,
             "initiated_by": 1,
-            "approval_status": "REJECTED",
+            "approval_status": Status.REJECTED.value,
         }
     ]
     mocker.patch.object(comms, "get_datasets_associations", return_value=dset_assocs)

--- a/cli/medperf/tests/comms/test_rest.py
+++ b/cli/medperf/tests/comms/test_rest.py
@@ -4,7 +4,7 @@ import requests
 from unittest.mock import mock_open, ANY
 
 from medperf import config
-from medperf.enums import Role
+from medperf.enums import Role, Status
 from medperf.ui.interface import UI
 from medperf.comms.rest import REST
 from medperf.tests.utils import rand_l
@@ -70,7 +70,7 @@ def server(mocker, ui):
                 "json": {
                     "benchmark": 1,
                     "dataset": 1,
-                    "approval_status": "PENDING",
+                    "approval_status": Status.PENDING.value,
                     "metadata": {},
                 }
             },
@@ -79,19 +79,19 @@ def server(mocker, ui):
             "_REST__set_approval_status",
             "put",
             200,
-            [f"{url}/mlcubes/1/benchmarks/1", "APPROVED"],
+            [f"{url}/mlcubes/1/benchmarks/1", Status.APPROVED.value],
             {},
             (f"{url}/mlcubes/1/benchmarks/1",),
-            {"json": {"approval_status": "APPROVED"}},
+            {"json": {"approval_status": Status.APPROVED.value}},
         ),
         (
             "_REST__set_approval_status",
             "put",
             200,
-            [f"{url}/mlcubes/1/benchmarks/1", "REJECTED"],
+            [f"{url}/mlcubes/1/benchmarks/1", Status.REJECTED.value],
             {},
             (f"{url}/mlcubes/1/benchmarks/1",),
-            {"json": {"approval_status": "REJECTED"}},
+            {"json": {"approval_status": Status.REJECTED.value}},
         ),
         (
             "change_password",
@@ -568,7 +568,7 @@ def test_associate_cube_posts_association_data(mocker, server, cube_uid, benchma
     # Arrange
     data = {
         "results": {},
-        "approval_status": "PENDING",
+        "approval_status": Status.PENDING.value,
         "model_mlcube": cube_uid,
         "benchmark": benchmark_uid,
         "metadata": {},
@@ -585,7 +585,7 @@ def test_associate_cube_posts_association_data(mocker, server, cube_uid, benchma
 
 @pytest.mark.parametrize("dataset_uid", rand_l(1, 5000, 2))
 @pytest.mark.parametrize("benchmark_uid", rand_l(1, 5000, 2))
-@pytest.mark.parametrize("status", ["APPROVED", "REJECTED"])
+@pytest.mark.parametrize("status", [Status.APPROVED.value, Status.REJECTED.value])
 def test_set_dataset_association_approval_sets_approval(
     mocker, server, dataset_uid, benchmark_uid, status
 ):
@@ -605,7 +605,7 @@ def test_set_dataset_association_approval_sets_approval(
 
 @pytest.mark.parametrize("mlcube_uid", rand_l(1, 5000, 2))
 @pytest.mark.parametrize("benchmark_uid", rand_l(1, 5000, 2))
-@pytest.mark.parametrize("status", ["APPROVED", "REJECTED"])
+@pytest.mark.parametrize("status", [Status.APPROVED.value, Status.REJECTED.value])
 def test_set_mlcube_association_approval_sets_approval(
     mocker, server, mlcube_uid, benchmark_uid, status
 ):

--- a/cli/medperf/tests/entities/test_dataset.py
+++ b/cli/medperf/tests/entities/test_dataset.py
@@ -1,3 +1,4 @@
+from medperf.enums import Status
 import pytest
 from unittest.mock import mock_open
 
@@ -17,7 +18,7 @@ REGISTRATION_MOCK = {
     "metadata": {"metadata_key": "metadata_value"},
     "generated_uid": "generated_uid",
     "input_data_hash": "input_data_hash",
-    "status": "PENDING",
+    "status": Status.PENDING.value,
     "uid": "uid",
     "state": "state",
 }
@@ -214,7 +215,7 @@ def test_request_registration_approval_skips_if_approved(mocker, all_uids, ui):
     uid = "1"
     spy = mocker.patch(PATCH_DATASET.format("approval_prompt"), return_value=True)
     reg = Dataset(uid, ui)
-    reg.status = "APPROVED"
+    reg.status = Status.APPROVED
 
     # Act
     reg.request_registration_approval(ui)

--- a/cli/medperf/tests/entities/test_registration.py
+++ b/cli/medperf/tests/entities/test_registration.py
@@ -1,4 +1,5 @@
 import os
+from medperf.enums import Status
 import pytest
 from pathlib import Path
 from unittest.mock import MagicMock
@@ -144,7 +145,7 @@ def test_request_approval_skips_if_approved(mocker, ui, reg_mocked_with_params):
     # Arrange
     spy = mocker.patch(PATCH_REGISTRATION.format("approval_prompt"), return_value=True)
     reg = Registration(*reg_mocked_with_params)
-    reg.status = "APPROVED"
+    reg.status = Status.APPROVED
 
     # Act
     reg.request_approval(ui)

--- a/cli/medperf/tests/entities/test_result.py
+++ b/cli/medperf/tests/entities/test_result.py
@@ -1,3 +1,4 @@
+from medperf.enums import Status
 import pytest
 from unittest.mock import MagicMock, call, ANY
 
@@ -125,7 +126,7 @@ def test_todict_returns_expected_keys(mocker, result):
 def test_request_approval_skips_if_already_approved(mocker, result, ui):
     # Arrange
     spy = mocker.patch(PATCH_RESULT.format("approval_prompt"))
-    result.status = "APPROVED"
+    result.status = Status.APPROVED
 
     # Act
     result.request_approval(ui)


### PR DESCRIPTION
The code now will work with python Enums for approval status (APPROVED, REJECTED, PENDING) instead of strings.