### PR TITLE
Reject benchmark execution and associations if the dataset has no server uid

### DIFF
--- a/cli/medperf/commands/dataset/associate.py
+++ b/cli/medperf/commands/dataset/associate.py
@@ -16,6 +16,10 @@ class AssociateDataset:
             benchmark_uid (int): UID of the benchmark to associate with
         """
         dset = Dataset(data_uid, ui)
+        if dset.uid is None:
+            msg = "The provided dataset is not registered."
+            pretty_error(msg, ui)
+
         benchmark = Benchmark.get(benchmark_uid, comms)
 
         if str(dset.preparation_cube_uid) != str(benchmark.data_preparation):

--- a/cli/medperf/commands/result/create.py
+++ b/cli/medperf/commands/result/create.py
@@ -72,6 +72,10 @@ class BenchmarkExecution:
         dset_prep_cube = str(self.dataset.preparation_cube_uid)
         bmark_prep_cube = str(self.benchmark.data_preparation)
 
+        if self.dataset.uid is None:
+            msg = "The provided dataset is not registered."
+            pretty_error(msg, self.ui)
+
         if dset_prep_cube != bmark_prep_cube:
             msg = "The provided dataset is not compatible with the specified benchmark."
             pretty_error(msg, self.ui)

--- a/cli/medperf/tests/commands/dataset/test_associate.py
+++ b/cli/medperf/tests/commands/dataset/test_associate.py
@@ -16,6 +16,7 @@ def dataset(mocker, request):
     dset = mocker.create_autospec(spec=Dataset)
     mocker.patch(PATCH_ASSOC.format("Dataset"), return_value=dset)
     dset.preparation_cube_uid = request.param
+    dset.uid = 1
     return dset
 
 
@@ -41,6 +42,23 @@ def test_fails_if_dataset_incompatible_with_benchmark(
     mocker, comms, ui, dataset, benchmark
 ):
     # Arrange
+    spy = mocker.patch(
+        PATCH_ASSOC.format("pretty_error"), side_effect=lambda *args, **kwargs: exit(),
+    )
+
+    # Act
+    with pytest.raises(SystemExit):
+        AssociateDataset.run(1, 1, comms, ui)
+
+    # Assert
+    spy.assert_called_once()
+
+
+@pytest.mark.parametrize("dataset", [1], indirect=True)
+@pytest.mark.parametrize("benchmark", [2], indirect=True)
+def test_fails_if_dataset_is_not_registered(mocker, comms, ui, dataset, benchmark):
+    # Arrange
+    dataset.uid = None
     spy = mocker.patch(
         PATCH_ASSOC.format("pretty_error"), side_effect=lambda *args, **kwargs: exit(),
     )

--- a/cli/medperf/tests/commands/result/test_create.py
+++ b/cli/medperf/tests/commands/result/test_create.py
@@ -74,6 +74,22 @@ def test_validate_fails_if_model_not_in_benchmark(mocker, execution, model_uid):
     spy.assert_called_once()
 
 
+def test_validate_fails_if_dataset_is_not_registered(mocker, execution):
+    # Arrange
+    execution.dataset.uid = None
+    spy = mocker.patch(
+        PATCH_EXECUTION.format("pretty_error"),
+        side_effect=lambda *args, **kwargs: exit(),
+    )
+
+    # Act
+    with pytest.raises(SystemExit):
+        execution.validate()
+
+    # Assert
+    spy.assert_called_once()
+
+
 def test_validate_passes_under_right_conditions(mocker, execution):
     # Arrange
     spy = mocker.patch(PATCH_EXECUTION.format("pretty_error"))


### PR DESCRIPTION
This PR makes sure that benchmark execution (`medperf result create`) and associating datasets to benchmarks (`medperf dataset associate`) will fail if the dataset is not yet submitted to the server. Closes #133 