### PR TITLE
Allow passing preparation cube for dataset create command

### DIFF
--- a/cli/medperf/commands/compatibility_test.py
+++ b/cli/medperf/commands/compatibility_test.py
@@ -212,7 +212,8 @@ class CompatibilityTestExecution:
             )
             data_path, labels_path = self.download_demo_data(self.data_uid)
             self.data_uid = DataPreparation.run(
-                self.benchmark_uid,
+                None,
+                self.data_prep,
                 data_path,
                 labels_path,
                 self.comms,

--- a/cli/medperf/commands/dataset/dataset.py
+++ b/cli/medperf/commands/dataset/dataset.py
@@ -27,7 +27,10 @@ def datasets(
 @clean_except
 def create(
     benchmark_uid: int = typer.Option(
-        ..., "--benchmark", "-b", help="UID of the desired benchmark"
+        None, "--benchmark", "-b", help="UID of the desired benchmark"
+    ),
+    data_prep_uid: int = typer.Option(
+        None, "--data_prep", "-p", help="UID of the desired preparation cube"
     ),
     data_path: str = typer.Option(
         ..., "--data_path", "-d", help="Location of the data to be prepared"
@@ -49,6 +52,7 @@ def create(
     ui = config.ui
     data_uid = DataPreparation.run(
         benchmark_uid,
+        data_prep_uid,
         data_path,
         labels_path,
         comms,

--- a/cli/medperf/tests/commands/dataset/test_create.py
+++ b/cli/medperf/tests/commands/dataset/test_create.py
@@ -38,7 +38,15 @@ def preparation(mocker, comms, ui, registration):
     )
     mocker.patch(PATCH_DATAPREP.format("Benchmark.get"), return_value=Benchmark())
     preparation = DataPreparation(
-        BENCHMARK_UID, DATA_PATH, LABELS_PATH, NAME, DESCRIPTION, LOCATION, comms, ui
+        BENCHMARK_UID,
+        None,
+        DATA_PATH,
+        LABELS_PATH,
+        NAME,
+        DESCRIPTION,
+        LOCATION,
+        comms,
+        ui,
     )
     mocker.patch(PATCH_DATAPREP.format("Registration"), return_value=registration)
     mocker.patch(PATCH_DATAPREP.format("Cube.get"), return_value=MockCube(True))
@@ -83,14 +91,35 @@ class TestWithDefaultUID:
             spy.asset_not_called()
 
     @pytest.mark.parametrize("cube_uid", rand_l(1, 5000, 5))
-    def test_get_prep_cube_gets_benchmark_cube(self, mocker, preparation, cube_uid):
+    def test_get_prep_cube_gets_prep_cube_if_provided(
+        self, mocker, preparation, cube_uid, comms, ui
+    ):
         # Arrange
-        preparation.benchmark.data_preparation = cube_uid
         spy = mocker.patch(
             PATCH_DATAPREP.format("Cube.get"), return_value=MockCube(True)
         )
 
         # Act
+        preparation = DataPreparation(None, cube_uid, *[""] * 5, comms, ui)
+        preparation.get_prep_cube()
+
+        # Assert
+        spy.assert_called_once_with(cube_uid, preparation.comms, preparation.ui)
+
+    @pytest.mark.parametrize("cube_uid", rand_l(1, 5000, 5))
+    def test_get_prep_cube_gets_benchmark_cube_if_provided(
+        self, mocker, preparation, cube_uid, comms, ui
+    ):
+        # Arrange
+        benchmark = Benchmark()
+        benchmark.data_preparation = cube_uid
+        mocker.patch(PATCH_DATAPREP.format("Benchmark.get"), return_value=benchmark)
+        spy = mocker.patch(
+            PATCH_DATAPREP.format("Cube.get"), return_value=MockCube(True)
+        )
+
+        # Act
+        preparation = DataPreparation(*[""] * 7, comms, ui)
         preparation.get_prep_cube()
 
         # Assert
@@ -99,7 +128,7 @@ class TestWithDefaultUID:
     @pytest.mark.parametrize("cube_uid", rand_l(1, 5000, 5))
     def test_get_prep_cube_checks_validity(self, mocker, preparation, cube_uid):
         # Arrange
-        preparation.benchmark.data_preparation = cube_uid
+        preparation.cube_uid = cube_uid
         mocker.patch(PATCH_DATAPREP.format("Cube.get"), return_value=MockCube(True))
         spy = mocker.patch(PATCH_DATAPREP.format("check_cube_validity"))
 
@@ -236,13 +265,35 @@ class TestWithDefaultUID:
         )
 
         # Act
-        DataPreparation.run("", "", "", comms, ui)
+        DataPreparation.run("", "", "", "", comms, ui)
 
         # Assert
         validate_spy.assert_called_once()
         get_cube_spy.assert_called_once()
         run_cube_spy.assert_called_once()
         create_reg_spy.assert_called_once()
+
+    @pytest.mark.parametrize("benchmark_uid", [None, "1"])
+    @pytest.mark.parametrize("cube_uid", [None, "1"])
+    def test_fails_if_invalid_params(
+        self, mocker, preparation, benchmark_uid, cube_uid, comms, ui
+    ):
+        # Arrange
+        num_arguments = int(benchmark_uid is None) + int(cube_uid is None)
+
+        spy = mocker.patch(
+            PATCH_DATAPREP.format("pretty_error"), side_effect=lambda *args: exit()
+        )
+
+        # Act
+        # Assert
+
+        if num_arguments != 1:
+            with pytest.raises(SystemExit):
+                DataPreparation.run(benchmark_uid, cube_uid, *[""] * 5, comms, ui)
+            spy.assert_called_once()
+        else:
+            spy.assert_not_called()
 
 
 @pytest.mark.parametrize(
@@ -256,7 +307,7 @@ def test_run_returns_registration_generated_uid(
     mocker.patch("os.path.exists", return_value=True)
 
     # Act
-    returned_uid = DataPreparation.run("", "", "", comms, ui)
+    returned_uid = DataPreparation.run("", "", "", "", comms, ui)
 
     # Assert
     assert returned_uid == registration.generated_uid


### PR DESCRIPTION
This PR allows `medperf dataset create` to receive either a benchmark uid or (exclusive) a preparation cube uid. Closes #227 