### PR TITLE
Compatibility test Bug fixes

### DIFF
--- a/cli/medperf/commands/compatibility_test.py
+++ b/cli/medperf/commands/compatibility_test.py
@@ -65,7 +65,8 @@ class CompatibilityTestExecution:
         ui: UI,
     ):
         self.benchmark_uid = benchmark_uid
-        self.benchmark = None
+        self.demo_dataset_url = None
+        self.demo_dataset_hash = None
         self.data_uid = data_uid
         self.dataset = None
         self.data_prep = data_prep
@@ -108,36 +109,26 @@ class CompatibilityTestExecution:
             self.set_cube_uid("data_prep", benchmark.data_preparation)
             self.set_cube_uid("model", benchmark.reference_model)
             self.set_cube_uid("evaluator", benchmark.evaluator)
-            demo_dataset_url = benchmark.demo_dataset_url
-            demo_dataset_hash = benchmark.demo_dataset_hash
+            self.demo_dataset_url = benchmark.demo_dataset_url
+            self.demo_dataset_hash = benchmark.demo_dataset_hash
         else:
             self.set_cube_uid("data_prep")
             self.set_cube_uid("model")
             self.set_cube_uid("evaluator")
-            demo_dataset_url = None
-            demo_dataset_hash = None
-
-        self.benchmark = Benchmark.tmp(
-            self.data_prep,
-            self.model,
-            self.evaluator,
-            demo_dataset_url,
-            demo_dataset_hash,
-        )
-        self.benchmark_uid = self.benchmark.uid
 
     def execute_benchmark(self):
         """Runs the benchmark execution flow given the specified testing parameters
         """
+        benchmark = Benchmark.tmp(self.data_prep, self.model, self.evaluator)
         BenchmarkExecution.run(
-            self.benchmark_uid,
+            benchmark.uid,
             self.data_uid,
             self.model,
             self.comms,
             self.ui,
             run_test=True,
         )
-        return Result(self.benchmark_uid, self.dataset.uid, self.model)
+        return Result(benchmark.uid, self.dataset.uid, self.model)
 
     def set_cube_uid(self, attr: str, fallback: any = None):
         """Assigns the attr used for testing according to the initialization parameters.
@@ -200,17 +191,12 @@ class CompatibilityTestExecution:
         logging.info("Establishing data_uid for test execution")
         logging.info("Looking if dataset exists as a prepared dataset")
         if self.data_uid is not None:
-            uid_hint = self.data_uid
-            data_storage = storage_path(config.data_storage)
-            data_uids = get_uids(data_storage)
-            match_uids = [uid for uid in data_uids if uid.startswith(str(uid_hint))]
-            if len(match_uids) > 0:
-                self.dataset = Dataset(self.data_uid, self.ui)
-        if self.dataset is None:
-            logging.info(
-                "No dataset found with provided uid. Using benchmark demo dataset"
-            )
-            data_path, labels_path = self.download_demo_data(self.data_uid)
+            self.dataset = Dataset(self.data_uid, self.ui)
+            # to avoid 'None' as a uid
+            self.data_prep = self.dataset.preparation_cube_uid
+        else:
+            logging.info("Using benchmark demo dataset")
+            data_path, labels_path = self.download_demo_data()
             self.data_uid = DataPreparation.run(
                 None,
                 self.data_prep,
@@ -226,20 +212,15 @@ class CompatibilityTestExecution:
             self.dataset.uid = self.data_uid
             self.dataset.set_registration()
 
-    def download_demo_data(self, data_uid: str = None):
+    def download_demo_data(self):
         """Retrieves the demo dataset associated to the specified benchmark
 
-        Arguments:
-            data_uid (str): Data UID to try and search locally as a demo dataset
         Returns:
             data_path (str): Location of the downloaded data
             labels_path (str): Location of the downloaded labels
         """
-        if data_uid is not None:
-            dset_hash = data_uid
-        else:
-            dset_hash = self.benchmark.demo_dataset_hash
-        dset_url = self.benchmark.demo_dataset_url
+        dset_hash = self.demo_dataset_hash
+        dset_url = self.demo_dataset_url
         file_path = self.comms.get_benchmark_demo_dataset(dset_url, dset_hash)
 
         # Check demo dataset integrity

--- a/cli/medperf/commands/compatibility_test.py
+++ b/cli/medperf/commands/compatibility_test.py
@@ -212,7 +212,8 @@ class CompatibilityTestExecution:
             )
             data_path, labels_path = self.download_demo_data(self.data_uid)
             self.data_uid = DataPreparation.run(
-                self.benchmark_uid,
+                None,
+                self.data_prep,
                 data_path,
                 labels_path,
                 self.comms,

--- a/cli/medperf/commands/compatibility_test.py
+++ b/cli/medperf/commands/compatibility_test.py
@@ -13,7 +13,7 @@ from medperf.entities.dataset import Dataset
 from medperf.entities.benchmark import Benchmark
 from medperf.commands.dataset.create import DataPreparation
 from medperf.commands.result.create import BenchmarkExecution
-from medperf.utils import pretty_error, untar, get_file_sha1, get_uids, storage_path
+from medperf.utils import pretty_error, untar, get_file_sha1, storage_path
 
 
 class CompatibilityTestExecution:

--- a/cli/medperf/commands/compatibility_test.py
+++ b/cli/medperf/commands/compatibility_test.py
@@ -128,7 +128,7 @@ class CompatibilityTestExecution:
             self.ui,
             run_test=True,
         )
-        return Result(benchmark.uid, self.dataset.uid, self.model)
+        return Result(benchmark.uid, self.dataset.generated_uid, self.model)
 
     def set_cube_uid(self, attr: str, fallback: any = None):
         """Assigns the attr used for testing according to the initialization parameters.
@@ -206,11 +206,7 @@ class CompatibilityTestExecution:
                 self.ui,
                 run_test=True,
             )
-            # Dataset will not be registered, so we must mock its uid
-            logging.info("Defining local data uid")
             self.dataset = Dataset(self.data_uid, self.ui)
-            self.dataset.uid = self.data_uid
-            self.dataset.set_registration()
 
     def download_demo_data(self):
         """Retrieves the demo dataset associated to the specified benchmark

--- a/cli/medperf/commands/compatibility_test.py
+++ b/cli/medperf/commands/compatibility_test.py
@@ -128,6 +128,9 @@ class CompatibilityTestExecution:
             self.ui,
             run_test=True,
         )
+        # Datasets associated with results of compatibility-test are identified
+        # by the generated uid. Server uid is not be applicable in the case
+        # of unregistered datasets.
         return Result(benchmark.uid, self.dataset.generated_uid, self.model)
 
     def set_cube_uid(self, attr: str, fallback: any = None):

--- a/cli/medperf/commands/dataset/dataset.py
+++ b/cli/medperf/commands/dataset/dataset.py
@@ -27,7 +27,10 @@ def datasets(
 @clean_except
 def create(
     benchmark_uid: int = typer.Option(
-        ..., "--benchmark", "-b", help="UID of the desired benchmark"
+        None, "--benchmark", "-b", help="UID of the desired benchmark"
+    ),
+    data_prep_uid: int = typer.Option(
+        None, "--data_prep", "-p", help="UID of the desired preparation cube"
     ),
     data_path: str = typer.Option(
         ..., "--data_path", "-d", help="Location of the data to be prepared"
@@ -49,6 +52,7 @@ def create(
     ui = config.ui
     data_uid = DataPreparation.run(
         benchmark_uid,
+        data_prep_uid,
         data_path,
         labels_path,
         comms,

--- a/cli/medperf/commands/result/create.py
+++ b/cli/medperf/commands/result/create.py
@@ -72,7 +72,7 @@ class BenchmarkExecution:
         dset_prep_cube = str(self.dataset.preparation_cube_uid)
         bmark_prep_cube = str(self.benchmark.data_preparation)
 
-        if self.dataset.uid is None:
+        if self.dataset.uid is None and not self.run_test:
             msg = "The provided dataset is not registered."
             pretty_error(msg, self.ui)
 
@@ -119,7 +119,15 @@ class BenchmarkExecution:
         labels_path = self.dataset.labels_path
 
         self.ui.text = "Evaluating results"
-        out_path = results_path(self.benchmark_uid, self.model_uid, self.dataset.uid)
+        if not self.run_test:
+            out_path = results_path(
+                self.benchmark_uid, self.model_uid, self.dataset.uid
+            )
+        else:
+            out_path = results_path(
+                self.benchmark_uid, self.model_uid, self.dataset.generated_uid
+            )
+
         self.evaluator.run(
             self.ui,
             task="evaluate",

--- a/cli/medperf/tests/commands/dataset/test_create.py
+++ b/cli/medperf/tests/commands/dataset/test_create.py
@@ -119,16 +119,14 @@ class TestWithDefaultUID:
         )
 
         # Act
-        preparation = DataPreparation(*[""] * 7, comms, ui)
+        preparation = DataPreparation(cube_uid, None, *[""] * 5, comms, ui)
         preparation.get_prep_cube()
 
         # Assert
         spy.assert_called_once_with(cube_uid, preparation.comms, preparation.ui)
 
-    @pytest.mark.parametrize("cube_uid", rand_l(1, 5000, 5))
-    def test_get_prep_cube_checks_validity(self, mocker, preparation, cube_uid):
+    def test_get_prep_cube_checks_validity(self, mocker, preparation):
         # Arrange
-        preparation.cube_uid = cube_uid
         mocker.patch(PATCH_DATAPREP.format("Cube.get"), return_value=MockCube(True))
         spy = mocker.patch(PATCH_DATAPREP.format("check_cube_validity"))
 
@@ -281,16 +279,14 @@ class TestWithDefaultUID:
         # Arrange
         num_arguments = int(benchmark_uid is None) + int(cube_uid is None)
 
-        spy = mocker.patch(
-            PATCH_DATAPREP.format("pretty_error"), side_effect=lambda *args: exit()
-        )
+        spy = mocker.patch(PATCH_DATAPREP.format("pretty_error"))
 
         # Act
+        preparation = DataPreparation(benchmark_uid, cube_uid, *[""] * 5, comms, ui)
+        preparation.validate()
         # Assert
 
         if num_arguments != 1:
-            with pytest.raises(SystemExit):
-                DataPreparation.run(benchmark_uid, cube_uid, *[""] * 5, comms, ui)
             spy.assert_called_once()
         else:
             spy.assert_not_called()

--- a/cli/medperf/tests/commands/dataset/test_create.py
+++ b/cli/medperf/tests/commands/dataset/test_create.py
@@ -38,7 +38,15 @@ def preparation(mocker, comms, ui, registration):
     )
     mocker.patch(PATCH_DATAPREP.format("Benchmark.get"), return_value=Benchmark())
     preparation = DataPreparation(
-        BENCHMARK_UID, DATA_PATH, LABELS_PATH, NAME, DESCRIPTION, LOCATION, comms, ui
+        BENCHMARK_UID,
+        None,
+        DATA_PATH,
+        LABELS_PATH,
+        NAME,
+        DESCRIPTION,
+        LOCATION,
+        comms,
+        ui,
     )
     mocker.patch(PATCH_DATAPREP.format("Registration"), return_value=registration)
     mocker.patch(PATCH_DATAPREP.format("Cube.get"), return_value=MockCube(True))
@@ -83,14 +91,35 @@ class TestWithDefaultUID:
             spy.asset_not_called()
 
     @pytest.mark.parametrize("cube_uid", rand_l(1, 5000, 5))
-    def test_get_prep_cube_gets_benchmark_cube(self, mocker, preparation, cube_uid):
+    def test_get_prep_cube_gets_prep_cube_if_provided(
+        self, mocker, preparation, cube_uid, comms, ui
+    ):
         # Arrange
-        preparation.benchmark.data_preparation = cube_uid
         spy = mocker.patch(
             PATCH_DATAPREP.format("Cube.get"), return_value=MockCube(True)
         )
 
         # Act
+        preparation = DataPreparation(None, cube_uid, *[""] * 5, comms, ui)
+        preparation.get_prep_cube()
+
+        # Assert
+        spy.assert_called_once_with(cube_uid, preparation.comms, preparation.ui)
+
+    @pytest.mark.parametrize("cube_uid", rand_l(1, 5000, 5))
+    def test_get_prep_cube_gets_benchmark_cube_if_provided(
+        self, mocker, preparation, cube_uid, comms, ui
+    ):
+        # Arrange
+        benchmark = Benchmark()
+        benchmark.data_preparation = cube_uid
+        mocker.patch(PATCH_DATAPREP.format("Benchmark.get"), return_value=benchmark)
+        spy = mocker.patch(
+            PATCH_DATAPREP.format("Cube.get"), return_value=MockCube(True)
+        )
+
+        # Act
+        preparation = DataPreparation(*[""] * 7, comms, ui)
         preparation.get_prep_cube()
 
         # Assert
@@ -99,7 +128,7 @@ class TestWithDefaultUID:
     @pytest.mark.parametrize("cube_uid", rand_l(1, 5000, 5))
     def test_get_prep_cube_checks_validity(self, mocker, preparation, cube_uid):
         # Arrange
-        preparation.benchmark.data_preparation = cube_uid
+        preparation.cube_uid = cube_uid
         mocker.patch(PATCH_DATAPREP.format("Cube.get"), return_value=MockCube(True))
         spy = mocker.patch(PATCH_DATAPREP.format("check_cube_validity"))
 
@@ -236,13 +265,35 @@ class TestWithDefaultUID:
         )
 
         # Act
-        DataPreparation.run("", "", "", comms, ui)
+        DataPreparation.run("", "", "", "", comms, ui)
 
         # Assert
         validate_spy.assert_called_once()
         get_cube_spy.assert_called_once()
         run_cube_spy.assert_called_once()
         create_reg_spy.assert_called_once()
+
+    @pytest.mark.parametrize("benchmark_uid", [None, "1"])
+    @pytest.mark.parametrize("cube_uid", [None, "1"])
+    def test_fails_if_invalid_params(
+        self, mocker, preparation, benchmark_uid, cube_uid, comms, ui
+    ):
+        # Arrange
+        num_arguments = int(benchmark_uid is None) + int(cube_uid is None)
+
+        spy = mocker.patch(
+            PATCH_DATAPREP.format("pretty_error"), side_effect=lambda *args: exit()
+        )
+
+        # Act
+        # Assert
+
+        if num_arguments != 1:
+            with pytest.raises(SystemExit):
+                DataPreparation.run(benchmark_uid, cube_uid, *[""] * 5, comms, ui)
+            spy.assert_called_once()
+        else:
+            spy.assert_not_called()
 
 
 @pytest.mark.parametrize(
@@ -256,7 +307,7 @@ def test_run_returns_registration_generated_uid(
     mocker.patch("os.path.exists", return_value=True)
 
     # Act
-    returned_uid = DataPreparation.run("", "", "", comms, ui)
+    returned_uid = DataPreparation.run("", "", "", "", comms, ui)
 
     # Assert
     assert returned_uid == registration.generated_uid

--- a/cli/medperf/tests/commands/test_compatibility_test.py
+++ b/cli/medperf/tests/commands/test_compatibility_test.py
@@ -260,7 +260,6 @@ def test_set_data_uid_sets_demo_data_uid_by_default(
 @pytest.mark.parametrize("data_uid", rand_l(1, 500, 5))
 def test_set_data_uid_keeps_passed_data_uid(mocker, default_setup, data_uid, comms, ui):
     # Arrange
-    mocker.patch(PATCH_TEST.format("get_uids"), return_value=[str(data_uid)])
     exec = CompatibilityTestExecution(1, data_uid, None, None, None, comms, ui)
 
     # Act
@@ -441,7 +440,6 @@ def test_run_uses_correct_uids(
     error_spy = mocker.patch(PATCH_TEST.format("pretty_error"))
     mocker.patch(PATCH_TEST.format("Benchmark.get"), return_value=bmk)
     mocker.patch("os.path.exists", return_value=False)
-    mocker.patch(PATCH_TEST.format("get_uids"), return_value=[str(data_uid)])
     mocker.patch(
         PATCH_TEST.format("CompatibilityTestExecution.download_demo_data"),
         return_value=("", ""),

--- a/cli/medperf/tests/commands/test_compatibility_test.py
+++ b/cli/medperf/tests/commands/test_compatibility_test.py
@@ -31,6 +31,7 @@ def benchmark(mocker):
 def dataset(mocker):
     dataset = mocker.create_autospec(spec=Dataset)
     dataset.uid = "uid"
+    dataset.preparation_cube_uid = "cube_uid"
     return dataset
 
 
@@ -88,7 +89,6 @@ def test_prepare_test_gets_benchmark_or_tmp(mocker, uid, benchmark, comms, ui):
     eval = "4"
     get_spy = mocker.patch(PATCH_TEST.format("Benchmark.get"), return_value=bmk)
     exec = CompatibilityTestExecution(uid, data, prep, model, eval, comms, ui)
-    tmp_spy = mocker.patch(PATCH_TEST.format("Benchmark.tmp"), return_value=bmk)
 
     # Act
     exec.prepare_test()
@@ -96,9 +96,8 @@ def test_prepare_test_gets_benchmark_or_tmp(mocker, uid, benchmark, comms, ui):
     # Assert
     if uid:
         get_spy.assert_called_once_with(uid, comms)
-    tmp_spy.assert_called_once_with(
-        prep, model, eval, bmk.demo_dataset_url, bmk.demo_dataset_hash
-    )
+    else:
+        get_spy.assert_not_called()
 
 
 @pytest.mark.parametrize("uid", [None, "1"])
@@ -106,7 +105,7 @@ def test_prepare_test_sets_uids(mocker, uid, benchmark, comms, ui):
     # Arrange
     bmk = benchmark(uid, 1, 2, 3)
     mocker.patch(PATCH_TEST.format("Benchmark.get"), return_value=bmk)
-    mocker.patch.object(Benchmark, "write")
+    # mocker.patch.object(Benchmark, "write")
     exec = CompatibilityTestExecution(uid, None, None, None, None, comms, ui)
     spy = mocker.spy(exec, "set_cube_uid")
     attrs = ["data_prep", "model", "evaluator"]
@@ -327,7 +326,6 @@ def test_run_returns_uids(
     # Arrange
     bmk = benchmark(bmk_uid, data_uid, model_uid, "3")
     mocker.patch(PATCH_TEST.format("Benchmark.get"), return_value=bmk)
-    mocker.patch(PATCH_TEST.format("Benchmark.tmp"), return_value=bmk)
     mocker.patch(PATCH_TEST.format("CompatibilityTestExecution.validate"))
     mocker.patch(PATCH_TEST.format("CompatibilityTestExecution.set_cube_uid"))
     mocker.patch(PATCH_TEST.format("CompatibilityTestExecution.set_data_uid"))
@@ -357,7 +355,6 @@ def test_download_demo_data_fails_if_incorrect_hash(mocker, benchmark, comms, ha
     bmk.demo_dataset_url = "url"
     bmk.demo_dataset_hash = hash
     mocker.patch(PATCH_TEST.format("Benchmark.get"), return_value=bmk)
-    mocker.patch(PATCH_TEST.format("Benchmark.tmp"), return_value=bmk)
     mocker.patch.object(comms, "get_benchmark_demo_dataset", return_value=("", ""))
     mocker.patch(PATCH_TEST.format("get_file_sha1"), return_value="hash")
     exec = CompatibilityTestExecution(uid, data, prep, model, eval, comms, ui)
@@ -390,7 +387,6 @@ def test_download_demo_data_extracts_expected_paths(
     bmk.demo_dataset_url = "url"
     bmk.demo_dataset_hash = "hash"
     mocker.patch(PATCH_TEST.format("Benchmark.get"), return_value=bmk)
-    mocker.patch(PATCH_TEST.format("Benchmark.tmp"), return_value=bmk)
     mocker.patch.object(comms, "get_benchmark_demo_dataset", return_value=("", ""))
     mocker.patch(PATCH_TEST.format("get_file_sha1"), return_value="hash")
 
@@ -413,27 +409,35 @@ def test_download_demo_data_extracts_expected_paths(
     assert labels_path == exp_labels_path
 
 
+@pytest.mark.parametrize("bmk_uid", rand_l(1, 500, 1) + [None])
 @pytest.mark.parametrize("data_uid", rand_l(1, 500, 1) + [None])
 @pytest.mark.parametrize("prep_uid", rand_l(1, 500, 1) + [None])
 @pytest.mark.parametrize("model_uid", rand_l(1, 500, 1) + [None])
 @pytest.mark.parametrize("eval_uid", rand_l(1, 500, 1) + [None])
 def test_run_uses_correct_uids(
-    mocker, benchmark, dataset, data_uid, prep_uid, model_uid, eval_uid, comms, ui
+    mocker,
+    benchmark,
+    dataset,
+    bmk_uid,
+    data_uid,
+    prep_uid,
+    model_uid,
+    eval_uid,
+    comms,
+    ui,
 ):
     # Arrange
-    bmk_uid = "1"
     bmk_prep_uid = "b1"
     bmk_model_uid = "b2"
     bmk_eval_uid = "b3"
     demo_dataset_uid = "d1"
     tmp_uid = "t1"
 
-    tmp_bmk = benchmark(tmp_uid, bmk_prep_uid, bmk_model_uid, bmk_eval_uid)
     bmk = benchmark(bmk_uid, bmk_prep_uid, bmk_model_uid, bmk_eval_uid)
     bmk.demo_dataset_url = "url"
     bmk.demo_dataset_hash = "hash"
 
-    mocker.patch(PATCH_TEST.format("CompatibilityTestExecution.validate"))
+    error_spy = mocker.patch(PATCH_TEST.format("pretty_error"))
     mocker.patch(PATCH_TEST.format("Benchmark.get"), return_value=bmk)
     mocker.patch("os.path.exists", return_value=False)
     mocker.patch(PATCH_TEST.format("get_uids"), return_value=[str(data_uid)])
@@ -447,13 +451,23 @@ def test_run_uses_correct_uids(
     mocker.patch(PATCH_TEST.format("Dataset"), return_value=dataset)
     mocker.patch(PATCH_TEST.format("Result"))
 
-    tmp_spy = mocker.patch(PATCH_TEST.format("Benchmark.tmp"), return_value=tmp_bmk)
+    def tmp_side_effect(prep, model, eval):
+        return benchmark(tmp_uid, prep, model, eval)
+
+    tmp_spy = mocker.patch(
+        PATCH_TEST.format("Benchmark.tmp"), side_effect=tmp_side_effect
+    )
     exec_spy = mocker.patch(PATCH_TEST.format("BenchmarkExecution.run"))
 
     exp_data_uid = demo_dataset_uid if data_uid is None else data_uid
-    exp_prep_uid = bmk_prep_uid if prep_uid is None else prep_uid
     exp_model_uid = bmk_model_uid if model_uid is None else model_uid
     exp_eval_uid = bmk_eval_uid if eval_uid is None else eval_uid
+    if prep_uid is not None:
+        exp_prep_uid = prep_uid
+    elif data_uid is not None:
+        exp_prep_uid = dataset.preparation_cube_uid
+    else:
+        exp_prep_uid = bmk_prep_uid
 
     # Act
     CompatibilityTestExecution.run(
@@ -461,13 +475,10 @@ def test_run_uses_correct_uids(
     )
 
     # Assert
-    tmp_spy.assert_called_once_with(
-        exp_prep_uid,
-        exp_model_uid,
-        exp_eval_uid,
-        bmk.demo_dataset_url,
-        bmk.demo_dataset_hash,
-    )
+    if error_spy.call_count != 0:
+        return
+
+    tmp_spy.assert_called_once_with(exp_prep_uid, exp_model_uid, exp_eval_uid)
     exec_spy.assert_called_once_with(
         tmp_uid, exp_data_uid, exp_model_uid, comms, ui, run_test=True
     )

--- a/cli/medperf/tests/commands/test_compatibility_test.py
+++ b/cli/medperf/tests/commands/test_compatibility_test.py
@@ -106,7 +106,6 @@ def test_prepare_test_sets_uids(mocker, uid, benchmark, comms, ui):
     # Arrange
     bmk = benchmark(uid, 1, 2, 3)
     mocker.patch(PATCH_TEST.format("Benchmark.get"), return_value=bmk)
-    # mocker.patch.object(Benchmark, "write")
     exec = CompatibilityTestExecution(uid, None, None, None, None, comms, ui)
     spy = mocker.spy(exec, "set_cube_uid")
     attrs = ["data_prep", "model", "evaluator"]

--- a/cli/medperf/tests/commands/test_compatibility_test.py
+++ b/cli/medperf/tests/commands/test_compatibility_test.py
@@ -31,6 +31,7 @@ def benchmark(mocker):
 def dataset(mocker):
     dataset = mocker.create_autospec(spec=Dataset)
     dataset.uid = "uid"
+    dataset.generated_uid = "gen_uid"
     dataset.preparation_cube_uid = "cube_uid"
     return dataset
 


### PR DESCRIPTION
This PR fixes a bug when `medperf test` is called without a benchmark. The problem was having the preparation cube uid as `None` in the case of having no provided benchmark and no provided preparation cube.
This PR also allows `medperf test` to be used with prepared, unregistered datasets.
Closes #225.

Includes also the changes from #232, which allows `medperf dataset create` to receive either a benchmark uid or (exclusive) a preparation cube uid.
Closes #227.