### PR TITLE
Fix Github pages custom domain being ignored

### DIFF
--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+docs.medperf.org


### PR DESCRIPTION
Since we are deploying github pages through github actions workflow using `mkdocs`, we need to make sure a `CNAME` file is present in the `docs` folder of the main branch, so that `mkdocs` copies this file to the `gh-pages` branch each time it updates the documentation website content. This `CNAME` file contains the custom domain and should be present in order to use the custom domain for github pages.

Closes #250 