### PR TITLE
fix the failing mkdocs command

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -45,7 +45,7 @@ plugins:
   - literate-nav:
       nav_file: SUMMARY.md
       
- extra:
+extra:
   analytics:
     provider: google
     property: G-QNE8JMYY88


### PR DESCRIPTION
A simple change (removal of an extra whitespace). It was causing `mkdocs` command to fail when building the docs.