### PR TITLE
Process-dependent temporary storage

### DIFF
--- a/cli/medperf/__main__.py
+++ b/cli/medperf/__main__.py
@@ -14,7 +14,7 @@ import medperf.commands.mlcube.mlcube as mlcube
 import medperf.commands.dataset.dataset as dataset
 from medperf.commands.auth import Login, PasswordChange
 import medperf.commands.benchmark.benchmark as benchmark
-from medperf.utils import init_storage, storage_path, cleanup
+from medperf.utils import init_storage, storage_path, cleanup, set_unique_tmp_config
 import medperf.commands.association.association as association
 from medperf.commands.compatibility_test import CompatibilityTestExecution
 
@@ -150,6 +150,8 @@ def main(
     config.evaluate_timeout = evaluate_timeout
     config.platform = platform
     config.cleanup = cleanup
+
+    set_unique_tmp_config() 
 
     if log_file is None:
         log_file = storage_path(config.log_file)

--- a/cli/medperf/__main__.py
+++ b/cli/medperf/__main__.py
@@ -151,7 +151,7 @@ def main(
     config.platform = platform
     config.cleanup = cleanup
 
-    set_unique_tmp_config() 
+    set_unique_tmp_config()
 
     if log_file is None:
         log_file = storage_path(config.log_file)

--- a/cli/medperf/tests/test_utils.py
+++ b/cli/medperf/tests/test_utils.py
@@ -107,6 +107,10 @@ def test_set_unique_tmp_config_adds_pid_to_tmp_vars(mocker, pid):
     # Arrange
     spy = mocker.patch("os.getpid", return_value=pid)
     pid = str(pid)
+    original_tmp_storage = config.tmp_storage
+    original_tmp_prefix = config.tmp_prefix
+    original_test_dset_prefix = config.test_dset_prefix
+    original_test_cube_prefix = config.test_cube_prefix
 
     # Act
     utils.set_unique_tmp_config()
@@ -117,6 +121,12 @@ def test_set_unique_tmp_config_adds_pid_to_tmp_vars(mocker, pid):
     assert config.tmp_prefix.endswith(pid)
     assert config.test_dset_prefix.endswith(pid)
     assert config.test_cube_prefix.endswith(pid)
+
+    # Cleanup
+    config.tmp_storage = original_tmp_storage
+    config.tmp_prefix = original_tmp_prefix
+    config.test_dset_prefix = original_test_dset_prefix
+    config.test_cube_prefix = original_test_cube_prefix
 
 
 def test_cleanup_removes_temporary_storage(mocker):

--- a/cli/medperf/tests/test_utils.py
+++ b/cli/medperf/tests/test_utils.py
@@ -85,7 +85,7 @@ def test_get_file_sha1_calculates_hash(mocker, file_io):
 
 @pytest.mark.parametrize(
     "existing_dirs",
-    [config_dirs[0:i] + config_dirs[i + 1 :] for i in range(len(config_dirs))],
+    [config_dirs[0:i] + config_dirs[i + 1:] for i in range(len(config_dirs))],
 )
 def test_init_storage_creates_nonexisting_paths(mocker, existing_dirs):
     # Arrange

--- a/cli/medperf/tests/test_utils.py
+++ b/cli/medperf/tests/test_utils.py
@@ -106,9 +106,8 @@ def test_init_storage_creates_nonexisting_paths(mocker, existing_dirs):
 def test_set_unique_tmp_config_adds_pid_to_tmp_vars(mocker, pid):
     # Arrange
     spy = mocker.patch("os.getpid", return_value=pid)
-    mocker.patch(
-        patch_utils.format("config"), return_value=__import__("medperf.config")
-    )
+    original_config = utils.config
+    utils.config = __import__("medperf").config
     pid = str(pid)
 
     # Act
@@ -120,6 +119,10 @@ def test_set_unique_tmp_config_adds_pid_to_tmp_vars(mocker, pid):
     assert utils.config.tmp_prefix.endswith(pid)
     assert utils.config.test_dset_prefix.endswith(pid)
     assert utils.config.test_cube_prefix.endswith(pid)
+    assert utils.config.cube_submission_id.endswith(pid)
+
+    # Cleanup
+    utils.config = original_config
 
 
 def test_cleanup_removes_temporary_storage(mocker):

--- a/cli/medperf/tests/test_utils.py
+++ b/cli/medperf/tests/test_utils.py
@@ -105,16 +105,18 @@ def test_init_storage_creates_nonexisting_paths(mocker, existing_dirs):
 @pytest.mark.parametrize("pid", [37, 864, 2890])
 def test_set_unique_tmp_config_adds_pid_to_tmp_vars(mocker, pid):
     # Arrange
-    spy = mocker.patch("os.getpid", return_value=pid)
-    original_config = utils.config
-    utils.config = __import__("medperf").config
+    mocker.patch("os.getpid", return_value=pid)
+    tmp_storage = utils.config.tmp_storage
+    tmp_prefix = utils.config.tmp_prefix
+    test_dset_prefix = utils.config.test_dset_prefix
+    test_cube_prefix = utils.config.test_cube_prefix
+    cube_submission_id = utils.config.cube_submission_id
     pid = str(pid)
 
     # Act
     utils.set_unique_tmp_config()
 
     # Assert
-    spy.assert_called_once()
     assert utils.config.tmp_storage.endswith(pid)
     assert utils.config.tmp_prefix.endswith(pid)
     assert utils.config.test_dset_prefix.endswith(pid)
@@ -122,7 +124,11 @@ def test_set_unique_tmp_config_adds_pid_to_tmp_vars(mocker, pid):
     assert utils.config.cube_submission_id.endswith(pid)
 
     # Cleanup
-    utils.config = original_config
+    utils.config.tmp_storage = tmp_storage
+    utils.config.tmp_prefix = tmp_prefix
+    utils.config.test_dset_prefix = test_dset_prefix
+    utils.config.test_cube_prefix = test_cube_prefix
+    utils.config.cube_submission_id = cube_submission_id
 
 
 def test_cleanup_removes_temporary_storage(mocker):

--- a/cli/medperf/tests/test_utils.py
+++ b/cli/medperf/tests/test_utils.py
@@ -102,6 +102,23 @@ def test_init_storage_creates_nonexisting_paths(mocker, existing_dirs):
     spy.assert_has_calls(exp_calls, any_order=True)
 
 
+@pytest.mark.parametrize("pid", [37, 864, 2890])
+def test_set_unique_tmp_config_adds_pid_to_tmp_vars(mocker, pid):
+    # Arrange
+    spy = mocker.patch("os.getpid", return_value=pid)
+    pid = str(pid)
+
+    # Act
+    utils.set_unique_tmp_config()
+
+    # Assert
+    spy.assert_called_once()
+    assert config.tmp_storage.endswith(pid)
+    assert config.tmp_prefix.endswith(pid)
+    assert config.test_dset_prefix.endswith(pid)
+    assert config.test_cube_prefix.endswith(pid)
+
+
 def test_cleanup_removes_temporary_storage(mocker):
     # Arrange
     mocker.patch("os.path.exists", return_value=True)

--- a/cli/medperf/tests/test_utils.py
+++ b/cli/medperf/tests/test_utils.py
@@ -85,7 +85,7 @@ def test_get_file_sha1_calculates_hash(mocker, file_io):
 
 @pytest.mark.parametrize(
     "existing_dirs",
-    [config_dirs[0:i] + config_dirs[i + 1:] for i in range(len(config_dirs))],
+    [config_dirs[0:i] + config_dirs[i + 1 :] for i in range(len(config_dirs))],
 )
 def test_init_storage_creates_nonexisting_paths(mocker, existing_dirs):
     # Arrange
@@ -106,27 +106,20 @@ def test_init_storage_creates_nonexisting_paths(mocker, existing_dirs):
 def test_set_unique_tmp_config_adds_pid_to_tmp_vars(mocker, pid):
     # Arrange
     spy = mocker.patch("os.getpid", return_value=pid)
+    mocker.patch(
+        patch_utils.format("config"), return_value=__import__("medperf.config")
+    )
     pid = str(pid)
-    original_tmp_storage = config.tmp_storage
-    original_tmp_prefix = config.tmp_prefix
-    original_test_dset_prefix = config.test_dset_prefix
-    original_test_cube_prefix = config.test_cube_prefix
 
     # Act
     utils.set_unique_tmp_config()
 
     # Assert
     spy.assert_called_once()
-    assert config.tmp_storage.endswith(pid)
-    assert config.tmp_prefix.endswith(pid)
-    assert config.test_dset_prefix.endswith(pid)
-    assert config.test_cube_prefix.endswith(pid)
-
-    # Cleanup
-    config.tmp_storage = original_tmp_storage
-    config.tmp_prefix = original_tmp_prefix
-    config.test_dset_prefix = original_test_dset_prefix
-    config.test_cube_prefix = original_test_cube_prefix
+    assert utils.config.tmp_storage.endswith(pid)
+    assert utils.config.tmp_prefix.endswith(pid)
+    assert utils.config.test_dset_prefix.endswith(pid)
+    assert utils.config.test_cube_prefix.endswith(pid)
 
 
 def test_cleanup_removes_temporary_storage(mocker):

--- a/cli/medperf/utils.py
+++ b/cli/medperf/utils.py
@@ -81,6 +81,7 @@ def set_unique_tmp_config():
     config.tmp_prefix += pid
     config.test_dset_prefix += pid
     config.test_cube_prefix += pid
+    config.cube_submission_id += pid
 
 
 def cleanup(extra_paths: List[str] = []):

--- a/cli/medperf/utils.py
+++ b/cli/medperf/utils.py
@@ -72,6 +72,17 @@ def init_storage():
             logging.warning(f"Tried to create existing folder {dir}")
 
 
+def set_unique_tmp_config():
+    """Set current process' temporary unique names
+    Enables simultaneous execution without cleanup collision
+    """
+    pid = str(os.getpid())
+    config.tmp_storage += pid
+    config.tmp_prefix += pid
+    config.test_dset_prefix += pid
+    config.test_cube_prefix += pid
+
+
 def cleanup(extra_paths: List[str] = []):
     """Removes clutter and unused files from the medperf folder structure.
     """


### PR DESCRIPTION
This PR implements process-dependent temporary storage. Having process-dependent temporary storage allows for simultaneous execution of commands, avoiding cleanup collision. This is done by appending the process ID to cleanup-related files at the beginning of every command. Closes #277.