### PR TITLE
Mkdocs build fix and install instructions

### DIFF
--- a/.github/workflows/docs-ci.yml
+++ b/.github/workflows/docs-ci.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: 3.x
-      - run: pip install mkdocs-material mkdocstrings[python] mkdocs-gen-files mkdocs-literate-nav
+      - run: pip install -r docs/requirements.txt
       - run: git config --global user.email "github-actions[bot]@users.noreply.github.com"
       - run: git config --global user.name "github-actions[bot]"
       - run: mkdocs gh-deploy --force

--- a/README.md
+++ b/README.md
@@ -196,3 +196,15 @@ Once all the requirements are met, running `sh test.sh` will:
 - Retrieve the demo dataset
 - Run the CLI demo using `cli/cli.sh`
 - cleanup temporary files
+
+## Documentation Contribution
+If you wish to contribute to our documentation, here are the steps for successfully building and serving documentation locally:
+
+- **Install dependencies:** We are currently using mkdocs for serving documentation. You can install all the requirements by running the following command:
+  ```
+  pip install -r docs/requirements.txt
+  ``` 
+- **Serve local documentation:** To run your own local server for visualizing documentation, run:
+  ```
+  mkdocs serve
+  ```

--- a/README.md
+++ b/README.md
@@ -208,3 +208,4 @@ If you wish to contribute to our documentation, here are the steps for successfu
   ```
   mkdocs serve
   ```
+- **Access local documentation:** Once mkdocs is done setting up the server, you should be able to access your local documentation website by heading to `http:/localhost:8000`

--- a/README.md
+++ b/README.md
@@ -208,4 +208,4 @@ If you wish to contribute to our documentation, here are the steps for successfu
   ```
   mkdocs serve
   ```
-- **Access local documentation:** Once mkdocs is done setting up the server, you should be able to access your local documentation website by heading to `http:/localhost:8000`
+- **Access local documentation:** Once mkdocs is done setting up the server, you should be able to access your local documentation website by heading to `http:/localhost:8000` on your browser.

--- a/cli/requirements.txt
+++ b/cli/requirements.txt
@@ -1,7 +1,7 @@
 typer~=0.6.0
 rich~=12.5.0
 PyYAML>=5.4,<6
-requests==2.26.0
+requests>=2.26.0
 yaspin==2.1.0
 tabulate==0.8.9
 pexpect==4.8.0

--- a/docs/gen_ref_pages.py
+++ b/docs/gen_ref_pages.py
@@ -9,7 +9,7 @@ import mkdocs_gen_files
 nav = mkdocs_gen_files.Nav()
 
 build_params = [
-    ("cli/medperf", "cli", "cli/medperf", "reference"),
+    ("cli/medperf", "cli/medperf", "cli/medperf", "reference"),
     # ("server", "server", "", "reference"),
 ]
 

--- a/docs/gen_ref_pages.py
+++ b/docs/gen_ref_pages.py
@@ -9,7 +9,7 @@ import mkdocs_gen_files
 nav = mkdocs_gen_files.Nav()
 
 build_params = [
-    ("cli/medperf", "cli/medperf", "cli/medperf", "reference"),
+    ("cli/medperf", "cli", "cli/medperf", "reference"),
     # ("server", "server", "", "reference"),
 ]
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,9 +1,8 @@
-mkdocs==1.2.4
+mkdocs==1.4.1
 mkdocs-autorefs==0.4.1
-mkdocs-gen-files==0.3.4
-mkdocs-git-revision-date-plugin==0.3.2
-mkdocs-literate-nav==0.4.1
-mkdocs-material==8.2.5
-mkdocs-material-extensions==1.0.3
-mkdocstrings==0.18.1
-mkdocstrings-python-legacy==0.2.2
+mkdocs-gen-files==0.4.0
+mkdocs-literate-nav==0.5.0
+mkdocs-material==8.5.7
+mkdocs-material-extensions==1.1
+mkdocstrings==0.19.0
+mkdocstrings-python==0.7.1

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,9 @@
+mkdocs==1.2.4
+mkdocs-autorefs==0.4.1
+mkdocs-gen-files==0.3.4
+mkdocs-git-revision-date-plugin==0.3.2
+mkdocs-literate-nav==0.4.1
+mkdocs-material==8.2.5
+mkdocs-material-extensions==1.0.3
+mkdocstrings==0.18.1
+mkdocstrings-python-legacy==0.2.2


### PR DESCRIPTION
This PR addresses a hidden bug that caused mkdocs to fail at build/serve time. This was caused by a build param that was updated some time ago.

Additionally, this PR includes a `requirements.txt` file and instructions for running mkdocs locally, for documentation contributions.