### PR TITLE
Decouple UI from low-level logic

### DIFF
--- a/cli/medperf/comms/factory.py
+++ b/cli/medperf/comms/factory.py
@@ -1,6 +1,6 @@
 from .rest import REST
 from .interface import Comms
-from medperf.utils import pretty_error
+from medperf.exceptions import InvalidArgumentError
 
 
 class CommsFactory:
@@ -10,4 +10,5 @@ class CommsFactory:
         if name == "rest":
             return REST(host)
         else:
-            pretty_error("the indicated communication interface doesn't exist")
+            msg = "the indicated communication interface doesn't exist"
+            raise InvalidArgumentError(msg)

--- a/cli/medperf/comms/rest.py
+++ b/cli/medperf/comms/rest.py
@@ -7,11 +7,15 @@ from medperf.enums import Role, Status
 import medperf.config as config
 from medperf.comms.interface import Comms
 from medperf.utils import (
-    pretty_error,
     cube_path,
     storage_path,
     generate_tmp_uid,
     sanitize_json,
+)
+from medperf.exceptions import (
+    CommunicationRetrievalError, 
+    CommunicationAuthenticationError,
+    CommunicationRequestError
 )
 
 
@@ -52,7 +56,7 @@ class REST(Comms):
         res = self.__req(f"{self.server_url}/auth-token/", requests.post, json=body)
         if res.status_code != 200:
             log_response_error(res)
-            pretty_error("Unable to authenticate user with provided credentials")
+            CommunicationAuthenticationError("Unable to authenticate user with provided credentials")
         else:
             self.token = res.json()["token"]
 
@@ -69,8 +73,7 @@ class REST(Comms):
         res = self.__auth_post(f"{self.server_url}/me/password/", json=body)
         if res.status_code != 200:
             log_response_error(res)
-            pretty_error("Unable to change the current password")
-            return False
+            raise CommunicationRequestError("Unable to change the current password")
         return True
 
     def authenticate(self):
@@ -79,7 +82,7 @@ class REST(Comms):
             with open(cred_path) as f:
                 self.token = f.readline()
         else:
-            pretty_error(
+            raise CommunicationAuthenticationError(
                 "Couldn't find credentials file. Did you run 'medperf login' before?"
             )
 
@@ -108,7 +111,7 @@ class REST(Comms):
             return req_func(url, verify=self.cert, **kwargs)
         except requests.exceptions.SSLError as e:
             logging.error(f"Couldn't connect to {self.server_url}: {e}")
-            pretty_error(
+            raise requests.exceptions.SSLError(
                 "Couldn't connect to server through HTTPS. If running locally, "
                 "remember to provide the server certificate through --certificate"
             )
@@ -139,7 +142,7 @@ class REST(Comms):
         res = self.__auth_get(f"{self.server_url}/me/benchmarks")
         if res.status_code != 200:
             log_response_error(res)
-            pretty_error("there was an error retrieving the current user's benchmarks")
+            raise CommunicationRetrievalError("there was an error retrieving the current user's benchmarks")
 
         benchmarks = res.json()
         bm_dict = {bm["benchmark"]: bm for bm in benchmarks}
@@ -171,7 +174,7 @@ class REST(Comms):
         res = self.__auth_get(f"{self.server_url}/benchmarks/")
         if res.status_code != 200:
             log_response_error(res)
-            pretty_error("couldn't retrieve benchmarks")
+            raise CommunicationRetrievalError("couldn't retrieve benchmarks")
         return res.json()
 
     def get_benchmark(self, benchmark_uid: int) -> dict:
@@ -186,7 +189,7 @@ class REST(Comms):
         res = self.__auth_get(f"{self.server_url}/benchmarks/{benchmark_uid}")
         if res.status_code != 200:
             log_response_error(res)
-            pretty_error("the specified benchmark doesn't exist")
+            raise CommunicationRetrievalError("the specified benchmark doesn't exist")
         return res.json()
 
     def get_benchmark_models(self, benchmark_uid: int) -> List[int]:
@@ -201,7 +204,7 @@ class REST(Comms):
         res = self.__auth_get(f"{self.server_url}/benchmarks/{benchmark_uid}/models")
         if res.status_code != 200:
             log_response_error(res)
-            pretty_error("couldn't retrieve models for the specified benchmark")
+            raise CommunicationRetrievalError("couldn't retrieve models for the specified benchmark")
         models = res.json()
         model_uids = [model["id"] for model in models]
         return model_uids
@@ -230,7 +233,7 @@ class REST(Comms):
         res = requests.get(demo_data_url)
         if res.status_code != 200:
             log_response_error(res)
-            pretty_error("couldn't download the demo dataset")
+            raise CommunicationRetrievalError("couldn't download the demo dataset")
 
         os.makedirs(demo_data_path, exist_ok=True)
 
@@ -246,7 +249,7 @@ class REST(Comms):
         res = self.__auth_get(f"{self.server_url}/me/benchmarks/")
         if res.status_code != 200:
             log_response_error(res)
-            pretty_error("wasn't able to retrieve user benchmarks")
+            raise CommunicationRetrievalError("wasn't able to retrieve user benchmarks")
         return res.json()
 
     def get_cubes(self) -> List[dict]:
@@ -258,7 +261,7 @@ class REST(Comms):
         res = self.__auth_get(f"{self.server_url}/mlcubes/")
         if res.status_code != 200:
             log_response_error(res)
-            pretty_error("couldn't retrieve mlcubes from the platform")
+            raise CommunicationRetrievalError("couldn't retrieve mlcubes from the platform")
         return res.json()
 
     def get_cube_metadata(self, cube_uid: int) -> dict:
@@ -273,7 +276,7 @@ class REST(Comms):
         res = self.__auth_get(f"{self.server_url}/mlcubes/{cube_uid}/")
         if res.status_code != 200:
             log_response_error(res)
-            pretty_error("the specified cube doesn't exist")
+            raise CommunicationRetrievalError("the specified cube doesn't exist")
         return res.json()
 
     def get_cube(self, url: str, cube_uid: int) -> str:
@@ -298,7 +301,7 @@ class REST(Comms):
         res = self.__auth_get(f"{self.server_url}/me/mlcubes/")
         if res.status_code != 200:
             log_response_error(res)
-            pretty_error("couldn't retrieve mlcubes created by the user")
+            raise CommunicationRetrievalError("couldn't retrieve mlcubes created by the user")
         return res.json()
 
     def get_cube_params(self, url: str, cube_uid: int) -> str:
@@ -347,7 +350,8 @@ class REST(Comms):
         res = requests.get(url)
         if res.status_code != 200:
             log_response_error(res)
-            pretty_error("There was a problem retrieving the specified file at " + url)
+            msg = "There was a problem retrieving the specified file at " + url
+            raise CommunicationRetrievalError(msg)
         else:
             c_path = cube_path(cube_uid)
             path = os.path.join(c_path, path)
@@ -369,7 +373,7 @@ class REST(Comms):
         res = self.__auth_post(f"{self.server_url}/benchmarks/", json=benchmark_dict)
         if res.status_code != 201:
             log_response_error(res)
-            pretty_error("Could not upload benchmark")
+            raise CommunicationRetrievalError("Could not upload benchmark")
         return res.json()
 
     def upload_mlcube(self, mlcube_body: dict) -> int:
@@ -384,7 +388,7 @@ class REST(Comms):
         res = self.__auth_post(f"{self.server_url}/mlcubes/", json=mlcube_body)
         if res.status_code != 201:
             log_response_error(res)
-            pretty_error("Could not upload the mlcube")
+            raise CommunicationRetrievalError("Could not upload the mlcube")
         return res.json()
 
     def get_datasets(self) -> List[dict]:
@@ -396,7 +400,7 @@ class REST(Comms):
         res = self.__auth_get(f"{self.server_url}/datasets/")
         if res.status_code != 200:
             log_response_error(res)
-            pretty_error("could not retrieve datasets from server")
+            raise CommunicationRetrievalError("could not retrieve datasets from server")
         return res.json()
 
     def get_dataset(self, dset_uid: str) -> dict:
@@ -411,7 +415,7 @@ class REST(Comms):
         res = self.__auth_get(f"{self.server_url}/datasets/{dset_uid}/")
         if res.status_code != 200:
             log_response_error(res)
-            pretty_error("Could not retrieve the specified dataset from server")
+            raise CommunicationRetrievalError("Could not retrieve the specified dataset from server")
         return res.json()
 
     def get_user_datasets(self) -> dict:
@@ -423,7 +427,7 @@ class REST(Comms):
         res = self.__auth_get(f"{self.server_url}/me/datasets/")
         if res.status_code != 200:
             log_response_error(res)
-            pretty_error("Could not retrieve datasets from server")
+            raise CommunicationRetrievalError("Could not retrieve datasets from server")
         return res.json()
 
     def upload_dataset(self, reg_dict: dict) -> int:
@@ -438,7 +442,7 @@ class REST(Comms):
         res = self.__auth_post(f"{self.server_url}/datasets/", json=reg_dict)
         if res.status_code != 201:
             log_response_error(res)
-            pretty_error("Could not upload the dataset")
+            raise CommunicationRequestError("Could not upload the dataset")
         return res.json()
 
     def get_result(self, result_uid: str) -> dict:
@@ -453,7 +457,7 @@ class REST(Comms):
         res = self.__auth_get(f"{self.server_url}/results/{result_uid}/")
         if res.status_code != 200:
             log_response_error(res)
-            pretty_error("Could not retrieve the specified result")
+            raise CommunicationRetrievalError("Could not retrieve the specified result")
         return res.json()
 
     def get_user_results(self) -> dict:
@@ -465,7 +469,7 @@ class REST(Comms):
         res = self.__auth_get(f"{self.server_url}/me/results/")
         if res.status_code != 200:
             log_response_error(res)
-            pretty_error("Could not retrieve results from server")
+            raise CommunicationRetrievalError("Could not retrieve results from server")
         return res.json()
 
     def upload_results(self, results_dict: dict) -> int:
@@ -480,7 +484,7 @@ class REST(Comms):
         res = self.__auth_post(f"{self.server_url}/results/", json=results_dict)
         if res.status_code != 201:
             log_response_error(res)
-            pretty_error("Could not upload the results")
+            raise CommunicationRequestError("Could not upload the results")
         return res.json()
 
     def associate_dset(self, data_uid: int, benchmark_uid: int, metadata: dict = {}):
@@ -500,7 +504,7 @@ class REST(Comms):
         res = self.__auth_post(f"{self.server_url}/datasets/benchmarks/", json=data)
         if res.status_code != 201:
             log_response_error(res)
-            pretty_error("Could not associate dataset to benchmark")
+            raise CommunicationRequestError("Could not associate dataset to benchmark")
 
     def associate_cube(self, cube_uid: str, benchmark_uid: int, metadata: dict = {}):
         """Create an MLCube-Benchmark association
@@ -520,7 +524,7 @@ class REST(Comms):
         res = self.__auth_post(f"{self.server_url}/mlcubes/benchmarks/", json=data)
         if res.status_code != 201:
             log_response_error(res)
-            pretty_error("Could not associate mlcube to benchmark")
+            raise CommunicationRequestError("Could not associate mlcube to benchmark")
 
     def set_dataset_association_approval(
         self, benchmark_uid: str, dataset_uid: str, status: str
@@ -536,7 +540,7 @@ class REST(Comms):
         res = self.__set_approval_status(url, status)
         if res.status_code != 200:
             log_response_error(res)
-            pretty_error(
+            raise CommunicationRequestError(
                 f"Could not approve association between dataset {dataset_uid} and benchmark {benchmark_uid}"
             )
 
@@ -554,7 +558,7 @@ class REST(Comms):
         res = self.__set_approval_status(url, status)
         if res.status_code != 200:
             log_response_error(res)
-            pretty_error(
+            raise CommunicationRequestError(
                 f"Could not approve association between mlcube {mlcube_uid} and benchmark {benchmark_uid}"
             )
 
@@ -567,7 +571,7 @@ class REST(Comms):
         res = self.__auth_get(f"{self.server_url}/me/datasets/associations/")
         if res.status_code != 200:
             log_response_error(res)
-            pretty_error("Could not retrieve user datasets associations")
+            raise CommunicationRetrievalError("Could not retrieve user datasets associations")
         return res.json()
 
     def get_cubes_associations(self) -> List[dict]:
@@ -579,5 +583,5 @@ class REST(Comms):
         res = self.__auth_get(f"{self.server_url}/me/mlcubes/associations/")
         if res.status_code != 200:
             log_response_error(res)
-            pretty_error("Could not retrieve user mlcubes associations")
+            raise CommunicationRetrievalError("Could not retrieve user mlcubes associations")
         return res.json()

--- a/cli/medperf/decorators.py
+++ b/cli/medperf/decorators.py
@@ -2,6 +2,8 @@ import logging
 import functools
 from collections.abc import Callable
 
+from medperf.utils import pretty_error
+
 
 def clean_except(func: Callable) -> Callable:
     """Decorator for handling unexpected errors. It allows logging
@@ -22,5 +24,6 @@ def clean_except(func: Callable) -> Callable:
         except Exception as e:
             logging.error("An unexpected error occured. Terminating.")
             logging.exception(e)
+            pretty_error(str(e))
 
     return wrapper

--- a/cli/medperf/entities/benchmark.py
+++ b/cli/medperf/entities/benchmark.py
@@ -6,7 +6,7 @@ from typing import List
 
 import medperf.config as config
 from medperf.entities.interface import Entity
-from medperf.utils import storage_path, pretty_error
+from medperf.utils import storage_path
 
 
 class Benchmark(Entity):
@@ -63,7 +63,7 @@ class Benchmark(Entity):
         except StopIteration:
             msg = "Couldn't iterate over benchmarks directory"
             logging.warning(msg)
-            pretty_error(msg)
+            raise RuntimeError(msg)
 
         benchmarks = [cls.get(uid) for uid in uids]
 

--- a/cli/medperf/entities/cube.py
+++ b/cli/medperf/entities/cube.py
@@ -7,7 +7,6 @@ from pathlib import Path
 
 from medperf.utils import (
     get_file_sha1,
-    pretty_error,
     untar,
     combine_proc_sp_text,
     list_files,
@@ -15,6 +14,7 @@ from medperf.utils import (
     cleanup
 )
 from medperf.entities.interface import Entity
+from medperf.exceptions import InvalidEntityError
 import medperf.config as config
 
 
@@ -90,7 +90,7 @@ class Cube(Entity):
         except StopIteration:
             msg = "Couldn't iterate over cubes directory"
             logging.warning(msg)
-            pretty_error(msg)
+            raise RuntimeError(msg)
 
         cubes = []
         for uid in uids:
@@ -134,7 +134,7 @@ class Cube(Entity):
         logging.error("Max download attempts reached")
         cube_path = os.path.join(storage_path(config.cubes_storage), str(cube_uid))
         cleanup([cube_path])
-        pretty_error("Could not successfully download the requested MLCube")
+        raise InvalidEntityError("Could not successfully download the requested MLCube")
 
     def download(self):
         """Downloads the required elements for an mlcube to run locally.

--- a/cli/medperf/entities/dataset.py
+++ b/cli/medperf/entities/dataset.py
@@ -6,10 +6,10 @@ from typing import List
 
 from medperf.utils import (
     get_uids,
-    pretty_error,
     storage_path,
 )
 from medperf.entities.interface import Entity
+from medperf.exceptions import InvalidArgumentError
 import medperf.config as config
 
 
@@ -111,7 +111,7 @@ class Dataset(Entity):
             generated_uids = next(os.walk(data_storage))[1]
         except StopIteration:
             logging.warning("Couldn't iterate over the dataset directory")
-            pretty_error("Couldn't iterate over the dataset directory")
+            raise RuntimeError("Couldn't iterate over the dataset directory")
         dsets = []
         for generated_uid in generated_uids:
             dsets.append(cls.from_generated_uid(generated_uid))
@@ -160,11 +160,12 @@ class Dataset(Entity):
         dsets = get_uids(data_storage)
         match = [uid for uid in dsets if uid.startswith(str(uid_hint))]
         if len(match) == 0:
-            pretty_error(f"No dataset was found with uid hint {uid_hint}.")
+            msg = f"No dataset was found with uid hint {uid_hint}."
         elif len(match) > 1:
-            pretty_error(f"Multiple datasets were found with uid hint {uid_hint}.")
+            msg = f"Multiple datasets were found with uid hint {uid_hint}."
         else:
             return match[0]
+        raise InvalidArgumentError(msg)
 
     def write(self):
         logging.info(f"Updating registration information for dataset: {self.uid}")

--- a/cli/medperf/exceptions.py
+++ b/cli/medperf/exceptions.py
@@ -1,0 +1,17 @@
+class CommunicationRetrievalError(Exception):
+	"""Raised when the communication interface can't retrieve an element"""
+
+class CommunicationRequestError(Exception):
+	"""Raised when the communication interface can't handle a request appropiately"""
+
+class CommunicationAuthenticationError(Exception):
+	"""Raised when the communication interface can't handle an authentication request"""
+
+class InvalidEntityError(Exception):
+	"""Raised when an entity is considered invalid"""
+
+class InvalidArgumentError(Exception):
+	"""Raised when an argument or set of arguments are consided invalid"""
+	
+class EntityRetrievalError(Exception):
+	"""Raised when an entity could not be retrieved"""

--- a/cli/medperf/tests/comms/test_rest.py
+++ b/cli/medperf/tests/comms/test_rest.py
@@ -138,14 +138,11 @@ def test_methods_exit_if_status_not_200(mocker, server, status, method_params):
     mocker.patch("requests.get", return_value=res)
     mocker.patch("requests.post", return_value=res)
     mocker.patch(patch_server.format("REST._REST__auth_req"), return_value=res)
-    spy = mocker.patch(patch_server.format("pretty_error"))
     method = getattr(server, method)
 
-    # Act
-    method(*args)
-
-    # Assert
-    spy.assert_called()
+    # Act & Assert
+    with pytest.raises(Exception):
+        method(*args)
 
 
 @pytest.mark.parametrize("uname", ["test", "admin", "user"])

--- a/cli/medperf/tests/entities/test_cube.py
+++ b/cli/medperf/tests/entities/test_cube.py
@@ -10,6 +10,7 @@ from medperf.utils import storage_path
 from medperf.tests.utils import cube_local_hashes_generator
 from medperf.tests.mocks.pexpect import MockPexpect
 from medperf.tests.mocks.requests import cube_metadata_generator
+from medperf.exceptions import InvalidEntityError
 
 PATCH_SERVER = "medperf.entities.benchmark.Comms.{}"
 PATCH_CUBE = "medperf.entities.cube.{}"
@@ -372,18 +373,17 @@ def test_get_cube_retries_configured_number_of_times(
     # Arrange
     mocker.patch(PATCH_CUBE.format("Cube.is_valid"), return_value=False)
     mocker.patch(PATCH_CUBE.format("cleanup"))
-    err_spy = mocker.patch(PATCH_CUBE.format("pretty_error"))
     spy = mocker.patch(PATCH_CUBE.format("Cube.download"))
     config.cube_get_max_attempts = max_attempts
     calls = [call()] * max_attempts
 
     # Act
-    uid = 1
-    Cube.get(uid)
+    with pytest.raises(InvalidEntityError):
+        uid = 1
+        Cube.get(uid)
 
     # Assert
     spy.assert_has_calls(calls)
-    err_spy.assert_called_once()
 
 
 @pytest.mark.parametrize("uid", [3, 75, 918])
@@ -391,29 +391,14 @@ def test_get_cube_deletes_cube_if_failed(mocker, comms, basic_body, no_local, ui
     # Arrange
     mocker.patch(PATCH_CUBE.format("Cube.is_valid"), return_value=False)
     spy = mocker.patch(PATCH_CUBE.format("cleanup"))
-    err_spy = mocker.patch(PATCH_CUBE.format("pretty_error"))
     cube_path = os.path.join(storage_path(config.cubes_storage), str(uid))
 
     # Act
-    Cube.get(uid)
+    with pytest.raises(InvalidEntityError):
+        Cube.get(uid)
 
     # Assert
     spy.assert_called_once_with([cube_path])
-    err_spy.assert_called_once()
-
-
-def test_get_cube_raises_error_if_failed(mocker, comms, basic_body, no_local):
-    # Arrange
-    uid = 1
-    mocker.patch(PATCH_CUBE.format("Cube.is_valid"), return_value=False)
-    mocker.patch(PATCH_CUBE.format("cleanup"))
-    err_spy = mocker.patch(PATCH_CUBE.format("pretty_error"))
-
-    # Act
-    Cube.get(uid)
-
-    # Assert
-    err_spy.assert_called_once()
 
 
 def test_get_cube_without_image_configures_mlcube(mocker, comms, basic_body, no_local):

--- a/cli/medperf/tests/entities/test_dataset.py
+++ b/cli/medperf/tests/entities/test_dataset.py
@@ -9,6 +9,7 @@ from medperf import utils
 from medperf.ui.interface import UI
 import medperf.config as config
 from medperf.entities.dataset import Dataset
+from medperf.exceptions import InvalidArgumentError
 
 
 REGISTRATION_MOCK = {
@@ -85,16 +86,10 @@ def test_all_fails_if_cant_iterate_data_storage(mocker, ui):
     # Arrange
     walk_out = iter([])
     mocker.patch(PATCH_DATASET.format("os.walk"), return_value=walk_out)
-    spy = mocker.patch(
-        PATCH_DATASET.format("pretty_error"), side_effect=lambda *args, **kwargs: exit()
-    )
 
-    # Act
-    with pytest.raises(SystemExit):
+    # Act & Assert
+    with pytest.raises(RuntimeError):
         Dataset.all()
-
-    # Assert
-    spy.assert_called_once()
 
 
 @pytest.mark.parametrize("all_uids", [[], ["1", "2", "3"]], indirect=True)
@@ -124,14 +119,11 @@ def test_dataset_metadata_is_backwards_compatible(mocker, ui):
 )
 def test_full_uid_fails_when_single_match_not_found(mocker, ui, all_uids):
     # Arrange
-    spy = mocker.patch(PATCH_DATASET.format("pretty_error"))
-
-    # Act
     uid = "1"
-    Dataset.from_generated_uid(uid)
 
-    # Arrange
-    spy.assert_called_once()
+    # Act & Assert
+    with pytest.raises(InvalidArgumentError):
+        Dataset.from_generated_uid(uid)
 
 
 @pytest.mark.parametrize("all_uids", [["12", "3"], ["3", "5", "12"]], indirect=True)

--- a/cli/medperf/tests/test_utils.py
+++ b/cli/medperf/tests/test_utils.py
@@ -8,6 +8,7 @@ from unittest.mock import mock_open, call, ANY
 from medperf import utils
 import medperf.config as config
 from medperf.tests.mocks import MockCube, MockTar
+from medperf.exceptions import InvalidEntityError
 
 parent = config.storage
 data = utils.storage_path(config.data_storage)
@@ -226,14 +227,12 @@ def test_cube_validity_fails_when_invalid(mocker, ui, is_valid):
     spy = mocker.patch(patch_utils.format("pretty_error"))
     cube = MockCube(is_valid)
 
-    # Act
-    utils.check_cube_validity(cube)
-
-    # Assert
+    # Act & Assert
     if not is_valid:
-        spy.assert_called_once()
+        with pytest.raises(InvalidEntityError):
+            utils.check_cube_validity(cube)
     else:
-        spy.assert_not_called()
+        utils.check_cube_validity(cube)
 
 
 @pytest.mark.parametrize("file", ["test.tar.bz", "path/to/file.tar.bz"])

--- a/cli/medperf/ui/factory.py
+++ b/cli/medperf/ui/factory.py
@@ -1,7 +1,7 @@
 from .cli import CLI
 from .interface import UI
 from .stdin import StdIn
-from medperf.utils import pretty_error
+from medperf.exceptions import InvalidArgumentError
 
 
 class UIFactory:
@@ -13,4 +13,5 @@ class UIFactory:
         elif name == "stdin":
             return StdIn()
         else:
-            pretty_error(f"{name}: the indicated UI interface doesn't exist")
+            msg = f"{name}: the indicated UI interface doesn't exist"
+            raise InvalidArgumentError(msg)

--- a/cli/medperf/utils.py
+++ b/cli/medperf/utils.py
@@ -19,6 +19,7 @@ from colorama import Fore, Style
 from pexpect.exceptions import TIMEOUT
 
 import medperf.config as config
+from medperf.exceptions import InvalidEntityError, CubeTimeoutError
 
 
 def storage_path(subpath: str):
@@ -257,7 +258,7 @@ def check_cube_validity(cube: "Cube"):
     ui = config.ui
     ui.text = "Checking cube MD5 hash..."
     if not cube.is_valid():
-        pretty_error("MD5 hash doesn't match")
+        raise InvalidEntityError("MD5 hash doesn't match")
     logging.info(f"Cube {cube.name} is valid")
     ui.print(f"> {cube.name} MD5 hash check complete")
 
@@ -343,8 +344,8 @@ def combine_proc_sp_text(proc: spawn) -> str:
         try:
             line = byte = proc.read(1)
         except TIMEOUT:
-            logging.info("Process timed out")
-            pretty_error("Process timed out")
+            logging.error("Process timed out")
+            raise TIMEOUT("Process timed out")
 
         while byte and not re.match(b"[\r\n]", byte):
             byte = proc.read(1)
@@ -417,7 +418,7 @@ def results_ids():
     except StopIteration:
         msg = "Couldn't iterate over the results directory"
         logging.warning(msg)
-        pretty_error(msg)
+        raise StopIteration(msg)
     logging.debug(f"Results ids: {results_ids}")
     return results_ids
 

--- a/cli/medperf/utils.py
+++ b/cli/medperf/utils.py
@@ -19,7 +19,7 @@ from colorama import Fore, Style
 from pexpect.exceptions import TIMEOUT
 
 import medperf.config as config
-from medperf.exceptions import InvalidEntityError, CubeTimeoutError
+from medperf.exceptions import InvalidEntityError
 
 
 def storage_path(subpath: str):


### PR DESCRIPTION
This PR removes calls that interact with the UI from low-level functionality, like entities and communication layers.  Direct calls to UI print funcionality have been removed, given they don't provide too much value (like indicating when a hash is generated, which the user doesn't really care about) or they can be handled on a different manner (like printing errors, which can be better managed through custom exceptions and decorators for pretty printing such scenarios).

With this, low-level functionality isn't concerned with how to display information to the user, which allows for greater control and usability of our code.

Closes #297.