### PR TITLE
Explicitly upgrade pyOpenSSL

### DIFF
--- a/.github/workflows/local-ci.yml
+++ b/.github/workflows/local-ci.yml
@@ -18,6 +18,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
+        pip install pyOpenSSL --upgrade
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
         if [ -f cli/requirements.txt ]; then pip install -e cli; fi
         if [ -f server/requirements.txt ]; then pip install -r server/requirements.txt; fi


### PR DESCRIPTION
This quickfix updates pyOpenSSL on github action `cli-local` so that it successfully runs the server.