### PR TITLE
Stream download files

### DIFF
--- a/cli/medperf/comms/rest.py
+++ b/cli/medperf/comms/rest.py
@@ -21,7 +21,7 @@ from medperf.exceptions import (
 
 
 def log_response_error(res, warn=False):
-    # note: status 403 might be also returned if a requested resource doesn't exist
+    # NOTE: status 403 might be also returned if a requested resource doesn't exist
     if warn:
         logging_method = logging.warning
     else:
@@ -251,14 +251,9 @@ class REST(Comms):
         if os.path.exists(filepath):
             return filepath
 
-        res = requests.get(demo_data_url)
-        if res.status_code != 200:
-            log_response_error(res)
-            raise CommunicationRetrievalError("couldn't download the demo dataset")
-
         os.makedirs(demo_data_path, exist_ok=True)
 
-        open(filepath, "wb+").write(res.content)
+        self.__download_direct_link(demo_data_url, filepath)
         return filepath
 
     def get_user_benchmarks(self) -> List[dict]:
@@ -359,18 +354,28 @@ class REST(Comms):
         return self.__get_cube_file(url, cube_path, image_path, image_name)
 
     def __get_cube_file(self, url: str, cube_path: str, path: str, filename: str):
-        res = requests.get(url)
-        if res.status_code != 200:
-            log_response_error(res)
-            msg = "There was a problem retrieving the specified file at " + url
-            raise CommunicationRetrievalError(msg)
-        else:
-            path = os.path.join(cube_path, path)
-            if not os.path.isdir(path):
-                os.makedirs(path, exist_ok=True)
-            filepath = os.path.join(path, filename)
-            open(filepath, "wb+").write(res.content)
-            return filepath
+        path = os.path.join(cube_path, path)
+        if not os.path.isdir(path):
+            os.makedirs(path, exist_ok=True)
+        filepath = os.path.join(path, filename)
+        self.__download_direct_link(url, filepath)
+        return filepath
+
+    def __download_direct_link(self, url: str, output_path: str):
+        """Downloads a direct-download-link file by streaming its contents. source:
+        https://stackoverflow.com/questions/16694907/download-large-file-in-python-with-requests
+        """
+        with requests.get(url, stream=True) as res:
+            if res.status_code != 200:
+                log_response_error(res)
+                msg = "There was a problem retrieving the specified file at " + url
+                raise CommunicationRetrievalError(msg)
+
+            with open(output_path, "wb") as f:
+                for chunk in res.iter_content(chunk_size=config.ddl_stream_chunk_size):
+                    # NOTE: if the response is chunk-encoded, this may not work
+                    # check whether this is common.
+                    f.write(chunk)
 
     def upload_benchmark(self, benchmark_dict: dict) -> int:
         """Uploads a new benchmark to the server.

--- a/cli/medperf/config.py
+++ b/cli/medperf/config.py
@@ -45,6 +45,7 @@ default_profile_name = "default"
 test_profile_name = "test"
 platform = "docker"
 default_page_size = 32  # This number was chosen arbitrarily
+ddl_stream_chunk_size = 10 * 1024 * 1024  # 10MB. This number was chosen arbitrarily
 comms = "REST"
 ui = "CLI"
 

--- a/cli/medperf/tests/mocks/requests.py
+++ b/cli/medperf/tests/mocks/requests.py
@@ -15,6 +15,15 @@ class MockResponse:
         text = "\n".join(strings)
         return text.encode()
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        pass
+
+    def iter_content(self, *args, **kwargs):
+        pass
+
 
 def benchmark_body(benchmark_uid):
     return benchmark_dict(


### PR DESCRIPTION
This PR modifies how direct links are downloaded with `requests.get`. Since these links may contain big data, it's better to stream the downloaded data into the disk rather than loading it to the RAM before writing to the disk.

Closes #276 