### PR TITLE
PR checks failure hotfix

### DIFF
--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -10,5 +10,7 @@ gunicorn==20.1.0
 google-cloud-secret-manager==2.8.0
 whitenoise==6.2.0
 pyOpenSSL==22.0.0
+#Temporary fix for pyOpenSSL. https://github.com/aws/aws-sam-cli/issues/4527#issuecomment-1369776818
+cryptography==38.0.4
 Werkzeug==2.2.3
 django-extensions==3.2.1


### PR DESCRIPTION
The quickfix for pyOpenSSL was removed by mistake. This PR re-fix it.