### PR TITLE
Make install from subdirectory explicit in installation docs

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -56,7 +56,7 @@ If using Docker, make sure [you can run Docker as a non-root user.](https://docs
 3. Install MedPerf package:
 
     ```bash
-    pip install cli
+    pip install ./cli
     ```
 
 4. Verify the installation:


### PR DESCRIPTION
Changes installation.md in docs to make the pip install step explicitly point to the subdirectory. 
When installing on my machine, the step as written looked for a PyPI package called "cli" -- thankfully none exists, but if it did, it would appear as a success to the user.
