### PR TITLE
Tutorial doc updates

### DIFF
--- a/cli/requirements.txt
+++ b/cli/requirements.txt
@@ -16,5 +16,5 @@ mlcube-singularity==0.0.9
 validators==0.18.2
 merge-args==0.1.4
 synapseclient==2.7.0
-setuptools==66.0.0
+setuptools==66.1.0
 schema==0.7.5

--- a/cli/requirements.txt
+++ b/cli/requirements.txt
@@ -16,5 +16,4 @@ mlcube-singularity==0.0.9
 validators==0.18.2
 merge-args==0.1.4
 synapseclient==2.7.0
-setuptools==66.1.0
 schema==0.7.5

--- a/cli/requirements.txt
+++ b/cli/requirements.txt
@@ -16,4 +16,5 @@ mlcube-singularity==0.0.9
 validators==0.18.2
 merge-args==0.1.4
 synapseclient==2.7.0
+setuptools==66.0.0
 schema==0.7.5

--- a/docs/getting_started/benchmark_owner_demo.md
+++ b/docs/getting_started/benchmark_owner_demo.md
@@ -266,7 +266,7 @@ You can create and submit your benchmark using the following command:
 ```bash
 medperf benchmark submit \
    --name tutorial_bmk \
-   --description "A benchmark created following MedPerf tutorial" \
+   --description "MedPerf demo bmk" \
    --demo-url "{{ demo_url }}" \
    --data-preparation-mlcube 1 \
    --reference-model-mlcube 2 \

--- a/docs/getting_started/model_owner_demo.md
+++ b/docs/getting_started/model_owner_demo.md
@@ -71,13 +71,13 @@ The submission should include the URLs of all the hosted files. For our tutorial
 a. The URL to the hosted mlcube manifest file:
 
 ```text
-{{ page.meta.model_mlcube }}
+{{ model_mlcube }}
 ```
 
 b. The URL to the hosted mlcube parameters file:
 
 ```text
-{{ page.meta.model_params }}
+{{ model_params }}
 ```
 
 c. The URL to the hosted additional files tarball file:
@@ -91,8 +91,8 @@ Command to submit:
 ```bash
 medperf mlcube submit \
    --name my-modelref-cube \
-   --mlcube-file "{{ page.meta.model_mlcube }}" \
-   --parameters-file "{{ page.meta.model_params }}" \
+   --mlcube-file "{{ model_mlcube }}" \
+   --parameters-file "{{ model_params }}" \
    --additional-file "{{ page.meta.model_add }}"
 ```
 

--- a/docs/getting_started/setup.md
+++ b/docs/getting_started/setup.md
@@ -17,7 +17,7 @@ For the purpose of the tutorials, you should spawn a local MedPerf server for th
 
     ```bash
     cd server
-    sh setup_dev_server.sh
+    sh setup-dev-server.sh
     ```
 
 The local server now is ready to recieve requests. You can always stop the server by pressing `CTRL`+`C` in the terminal where you ran the server.

--- a/tutorials_scripts/setup_benchmark_tutorial.sh
+++ b/tutorials_scripts/setup_benchmark_tutorial.sh
@@ -3,9 +3,16 @@ mkdir -p medperf_tutorial
 cd medperf_tutorial
 
 # Download a clean, unpackaged demo dataset
-wget https://storage.googleapis.com/medperf-storage/mock_xrv_demo_data.tar.gz
-tar -xf mock_xrv_demo_data.tar.gz
-rm mock_xrv_demo_data.tar.gz
+url=https://storage.googleapis.com/medperf-storage/mock_xrv_demo_data.tar.gz 
+filename=$(basename $url)
+
+if [ -x "$(which wget)" ] ; then
+    wget $url
+elif [ -x "$(which curl)" ]; then
+    curl -o $filename $url
+fi
+tar -xf $filename
+rm $filename
 rm paths.yaml
 
 # Copy the MLCubes to be used

--- a/tutorials_scripts/setup_data_tutorial.sh
+++ b/tutorials_scripts/setup_data_tutorial.sh
@@ -3,5 +3,12 @@ mkdir -p medperf_tutorial
 cd medperf_tutorial
 
 # Download a dataset
-wget https://storage.googleapis.com/medperf-storage/mock_chexpert.tar.gz
-tar -xf mock_chexpert.tar.gz
+url=https://storage.googleapis.com/medperf-storage/mock_chexpert.tar.gz
+filename=$(basename $url)
+
+if [ -x "$(which wget)" ] ; then
+    wget $url
+elif [ -x "$(which curl)" ]; then
+    curl -o $filename $url
+fi
+tar -xf $filename


### PR DESCRIPTION
## Changelog
* ~specify an older version of setuptools (66.1.0) so that importing synapseclient will work~ ← EDIT: noticed that @hasan7n also added a fix for this issue; I will remove my change to prevent merging conflicts
* reduce `submit`'s description  value to <20 characters in order to pass validation check:
  ```
  ❌ Field Validation Error:
  - description: ensure this value has at most 20 characters.
  ```
* fix filename in docs for running the dev server (unless underscores are desired?  Then renaming the script will be needed)
* add `curl` option to `tutorials_scripts/setup_benchmark_tutorial.sh` and `tutorials_scripts/setup_data_tutorial.sh` for users who don't have `wget`
* fix (?) broken elements called in the model_owner_demo README:
![Screen Shot 2023-06-13 at 11 20 02 PM](https://github.com/mlcommons/medperf/assets/9377970/72a65334-0c2d-4eab-a9d6-d94567ecfcfe)
   > **Note**: I don't actually know if this fixed it, as I don't see a change in my local preview.
