### PR TITLE
Fix documentation links

### DIFF
--- a/docs/getting_started/benchmark_owner_demo.md
+++ b/docs/getting_started/benchmark_owner_demo.md
@@ -1,7 +1,7 @@
 ---
 demo_url: https://storage.googleapis.com/medperf-storage/chestxray_tutorial/demo_data.tar.gz
 model_add: https://storage.googleapis.com/medperf-storage/chestxray_tutorial/cnn_weights.tar.gz
-assets_url: https://raw.githubusercontent.com/hasan7n/medperf/094d96006291290fc416b32c6d95cbcca73f200e/examples/chestxray/
+assets_url: https://raw.githubusercontent.com/mlcommons/medperf/7bcfddeade143f926d19b15021ba52dd38f0f362/examples/chestxray/
 tutorial_id: benchmark
 ---
 

--- a/docs/getting_started/model_owner_demo.md
+++ b/docs/getting_started/model_owner_demo.md
@@ -1,7 +1,7 @@
 ---
 demo_url: https://storage.googleapis.com/medperf-storage/chestxray_tutorial/demo_data.tar.gz
 model_add: https://storage.googleapis.com/medperf-storage/chestxray_tutorial/mobilenetv2_weights.tar.gz
-assets_url: https://raw.githubusercontent.com/hasan7n/medperf/094d96006291290fc416b32c6d95cbcca73f200e/examples/chestxray/
+assets_url: https://raw.githubusercontent.com/mlcommons/medperf/7bcfddeade143f926d19b15021ba52dd38f0f362/examples/chestxray/
 tutorial_id: model
 ---
 

--- a/docs/mlcubes/mlcube_models.md
+++ b/docs/mlcubes/mlcube_models.md
@@ -1,6 +1,6 @@
 ---
 name: Model MLCube
-url: https://github.com/mlcommons/medperf/examples/chestxray/model_custom_cnn
+url: https://github.com/mlcommons/medperf/tree/main/examples/chestxray/model_custom_cnn
 data_url: https://storage.googleapis.com/medperf-storage/chestxray_tutorial/sample_prepared_data.tar.gz
 weights_url: https://storage.googleapis.com/medperf-storage/chestxray_tutorial/cnn_weights.tar.gz
 ---

--- a/server/seed.py
+++ b/server/seed.py
@@ -5,8 +5,8 @@ import json
 import curlify
 
 ASSETS_URL = (
-    "https://raw.githubusercontent.com/hasan7n/medperf/"
-    "094d96006291290fc416b32c6d95cbcca73f200e/examples/chestxray/"
+    "https://raw.githubusercontent.com/mlcommons/medperf/"
+    "7bcfddeade143f926d19b15021ba52dd38f0f362/examples/chestxray/"
 )
 
 


### PR DESCRIPTION
Fix a broken link and use assets urls from the main medperf repository instead of forks in documentation