### PR TITLE
Use sha256 for hashing

### DIFF
--- a/cli/medperf/commands/benchmark/benchmark.py
+++ b/cli/medperf/commands/benchmark/benchmark.py
@@ -43,7 +43,7 @@ def submit(
         See `medperf mlcube submit --help` for more information""",
     ),
     demo_hash: str = typer.Option(
-        "", "--demo-hash", help="SHA1 of demonstration dataset tarball file"
+        "", "--demo-hash", help="Hash of demonstration dataset tarball file"
     ),
     data_preparation_mlcube: int = typer.Option(
         ..., "--data-preparation-mlcube", "-p", help="Data Preparation MLCube UID"
@@ -84,11 +84,12 @@ def associate(
     ),
     approval: bool = typer.Option(False, "-y", help="Skip approval step"),
     no_cache: bool = typer.Option(
-        False, "--no-cache", help="Execute the test even if results already exist",
+        False,
+        "--no-cache",
+        help="Execute the test even if results already exist",
     ),
 ):
-    """Associates a benchmark with a given mlcube or dataset. Only one option at a time.
-    """
+    """Associates a benchmark with a given mlcube or dataset. Only one option at a time."""
     AssociateBenchmark.run(
         benchmark_uid, model_uid, dataset_uid, approved=approval, no_cache=no_cache
     )
@@ -118,11 +119,12 @@ def run(
         help="Ignore failing model cubes, allowing for possibly submitting partial results",
     ),
     no_cache: bool = typer.Option(
-        False, "--no-cache", help="Execute even if results already exist",
+        False,
+        "--no-cache",
+        help="Execute even if results already exist",
     ),
 ):
-    """Runs the benchmark execution step for a given benchmark, prepared dataset and model
-    """
+    """Runs the benchmark execution step for a given benchmark, prepared dataset and model"""
     BenchmarkExecution.run(
         benchmark_uid,
         data_uid,
@@ -163,6 +165,5 @@ def view(
         help="Output file to store contents. If not provided, the output will be displayed",
     ),
 ):
-    """Displays the information of one or more benchmarks
-    """
+    """Displays the information of one or more benchmarks"""
     EntityView.run(entity_id, Benchmark, format, local, mine, output)

--- a/cli/medperf/commands/compatibility_test/utils.py
+++ b/cli/medperf/commands/compatibility_test/utils.py
@@ -1,4 +1,4 @@
-from medperf.utils import storage_path, get_folder_sha1
+from medperf.utils import storage_path, get_folder_hash
 from medperf.exceptions import InvalidArgumentError, InvalidEntityError
 
 from medperf.comms.entity_resources import resources
@@ -34,7 +34,7 @@ def download_demo_data(dset_url, dset_hash):
 
 
 def prepare_local_cube(path):
-    temp_uid = get_folder_sha1(path)
+    temp_uid = get_folder_hash(path)
     cubes_storage = storage_path(config.cubes_storage)
     dst = os.path.join(cubes_storage, temp_uid)
     os.symlink(path, dst)

--- a/cli/medperf/commands/dataset/create.py
+++ b/cli/medperf/commands/dataset/create.py
@@ -9,7 +9,7 @@ from medperf.entities.benchmark import Benchmark
 from medperf.utils import (
     remove_path,
     generate_tmp_path,
-    get_folder_sha1,
+    get_folder_hash,
     storage_path,
 )
 from medperf.exceptions import InvalidArgumentError
@@ -176,8 +176,8 @@ class DataPreparation:
 
     def generate_uids(self):
         """Auto-generates dataset UIDs for both input and output paths"""
-        self.in_uid = get_folder_sha1(self.data_path)
-        self.generated_uid = get_folder_sha1(self.out_datapath)
+        self.in_uid = get_folder_hash(self.data_path)
+        self.generated_uid = get_folder_hash(self.out_datapath)
 
     def to_permanent_path(self) -> str:
         """Renames the temporary data folder to permanent one using the hash of

--- a/cli/medperf/commands/mlcube/mlcube.py
+++ b/cli/medperf/commands/mlcube/mlcube.py
@@ -59,7 +59,7 @@ def submit(
         "-m",
         help="Identifier to download the mlcube file. See the description above",
     ),
-    mlcube_hash: str = typer.Option("", "--mlcube-hash", help="SHA1 of mlcube file"),
+    mlcube_hash: str = typer.Option("", "--mlcube-hash", help="hash of mlcube file"),
     parameters_file: str = typer.Option(
         "",
         "--parameters-file",
@@ -67,7 +67,7 @@ def submit(
         help="Identifier to download the parameters file. See the description above",
     ),
     parameters_hash: str = typer.Option(
-        "", "--parameters-hash", help="SHA1 of parameters file"
+        "", "--parameters-hash", help="hash of parameters file"
     ),
     additional_file: str = typer.Option(
         "",
@@ -76,7 +76,7 @@ def submit(
         help="Identifier to download the additional files tarball. See the description above",
     ),
     additional_hash: str = typer.Option(
-        "", "--additional-hash", help="SHA1 of additional file"
+        "", "--additional-hash", help="hash of additional file"
     ),
     image_file: str = typer.Option(
         "",
@@ -84,7 +84,7 @@ def submit(
         "-i",
         help="Identifier to download the image file. See the description above",
     ),
-    image_hash: str = typer.Option("", "--image-hash", help="SHA1 of image file"),
+    image_hash: str = typer.Option("", "--image-hash", help="hash of image file"),
 ):
     """Submits a new cube to the platform.\n
     The following assets:\n
@@ -122,7 +122,9 @@ def associate(
     model_uid: int = typer.Option(..., "--model_uid", "-m", help="Model UID"),
     approval: bool = typer.Option(False, "-y", help="Skip approval step"),
     no_cache: bool = typer.Option(
-        False, "--no-cache", help="Execute the test even if results already exist",
+        False,
+        "--no-cache",
+        help="Execute the test even if results already exist",
     ),
 ):
     """Associates an MLCube to a benchmark"""
@@ -155,6 +157,5 @@ def view(
         help="Output file to store contents. If not provided, the output will be displayed",
     ),
 ):
-    """Displays the information of one or more mlcubes
-    """
+    """Displays the information of one or more mlcubes"""
     EntityView.run(entity_id, Cube, format, local, mine, output)

--- a/cli/medperf/comms/entity_resources/resources.py
+++ b/cli/medperf/comms/entity_resources/resources.py
@@ -33,7 +33,7 @@ def get_cube(url: str, cube_path: str, expected_hash: str = None) -> str:
     Args:
         url (str): URL where the mlcube.yaml file can be downloaded.
         cube_path (str): Cube location.
-        expected_hash (str, optional): expected sha1 hash of the downloaded file
+        expected_hash (str, optional): expected hash of the downloaded file
 
     Returns:
         output_path (str): location where the mlcube.yaml file is stored locally.
@@ -53,7 +53,7 @@ def get_cube_params(url: str, cube_path: str, expected_hash: str = None) -> str:
     Args:
         url (str): URL where the parameters.yaml file can be downloaded.
         cube_path (str): Cube location.
-        expected_hash (str, optional): expected sha1 hash of the downloaded file
+        expected_hash (str, optional): expected hash of the downloaded file
 
     Returns:
         output_path (str): location where the parameters file is stored locally.
@@ -108,7 +108,9 @@ def get_cube_image(url: str, cube_path: str, hash_value: str = None) -> str:
 
 
 def get_cube_additional(
-    url: str, cube_path: str, expected_tarball_hash: str = None,
+    url: str,
+    cube_path: str,
+    expected_tarball_hash: str = None,
 ) -> str:
     """Retrieves additional files of an MLCube. The additional files
     will be in a compressed tarball file. The function will additionally
@@ -117,7 +119,7 @@ def get_cube_additional(
     Args:
         url (str): URL where the additional_files.tar.gz file can be downloaded.
         cube_path (str): Cube location.
-        expected_tarball_hash (str, optional): expected sha1 hash of tarball file
+        expected_tarball_hash (str, optional): expected hash of tarball file
 
     Returns:
         tarball_hash (str): The hash of the downloaded tarball file
@@ -145,7 +147,7 @@ def get_benchmark_demo_dataset(url: str, expected_hash: str = None) -> str:
 
     Args:
         url (str): URL where the compressed demo dataset file can be downloaded.
-        expected_hash (str, optional): expected sha1 hash of the downloaded file
+        expected_hash (str, optional): expected hash of the downloaded file
 
     Returns:
         output_path (str): location where the uncompressed demo dataset is stored locally.

--- a/cli/medperf/comms/entity_resources/utils.py
+++ b/cli/medperf/comms/entity_resources/utils.py
@@ -1,6 +1,6 @@
 import os
 from typing import Optional
-from medperf.utils import generate_tmp_path, get_file_sha1, verify_hash
+from medperf.utils import generate_tmp_path, get_file_hash, verify_hash
 from .sources import supported_sources
 from medperf.exceptions import InvalidArgumentError
 
@@ -62,7 +62,7 @@ def verify_or_get_hash(tmp_output_path: str, expected_hash: str) -> str:
     Returns:
         str: Calculated hash of the asset. Only returns if the hashes match
     """
-    calculated_hash = get_file_sha1(tmp_output_path)
+    calculated_hash = get_file_hash(tmp_output_path)
     verify_hash(calculated_hash, expected_hash)
     return calculated_hash
 

--- a/cli/medperf/entities/report.py
+++ b/cli/medperf/entities/report.py
@@ -47,7 +47,7 @@ class TestReport(Entity, MedperfBaseSchema):
         params = self.todict()
         del params["results"]
         params = str(params)
-        return hashlib.sha1(params.encode()).hexdigest()
+        return hashlib.sha256(params.encode()).hexdigest()
 
     def set_results(self, results):
         self.results = results

--- a/cli/medperf/entities/schemas.py
+++ b/cli/medperf/entities/schemas.py
@@ -77,7 +77,7 @@ class MedperfBaseSchema(BaseModel):
 class MedperfSchema(MedperfBaseSchema):
     for_test: bool = False
     id: Optional[int]
-    name: str = Field(..., max_length=60)
+    name: str = Field(..., max_length=64)
     owner: Optional[int]
     created_at: Optional[datetime]
     modified_at: Optional[datetime]

--- a/cli/medperf/tests/commands/dataset/test_create.py
+++ b/cli/medperf/tests/commands/dataset/test_create.py
@@ -201,7 +201,7 @@ class TestWithDefaultUID:
         self, mocker, in_path, out_path, preparation
     ):
         # Arrange
-        mocker.patch(PATCH_DATAPREP.format("get_folder_sha1"), side_effect=lambda x: x)
+        mocker.patch(PATCH_DATAPREP.format("get_folder_hash"), side_effect=lambda x: x)
         preparation.data_path = in_path
         preparation.out_datapath = out_path
 

--- a/cli/medperf/tests/comms/entity_resources/test_resources.py
+++ b/cli/medperf/tests/comms/entity_resources/test_resources.py
@@ -1,5 +1,5 @@
 import os
-from medperf.utils import base_storage_path, get_file_sha1
+from medperf.utils import base_storage_path, get_file_hash
 import pytest
 import medperf.config as config
 from medperf.comms.entity_resources import resources
@@ -12,7 +12,7 @@ url = "https://mock.url"
 def setup(mocker, fs):
     def download_resource_side_effect(url, outpath, expected_hash=None):
         fs.create_file(outpath, contents=url)
-        return get_file_sha1(outpath)
+        return get_file_hash(outpath)
 
     mocker.patch.object(
         resources, "download_resource", side_effect=download_resource_side_effect

--- a/cli/medperf/tests/entities/utils.py
+++ b/cli/medperf/tests/entities/utils.py
@@ -3,7 +3,7 @@ from medperf.utils import storage_path
 from medperf import config
 import yaml
 
-from medperf.utils import get_file_sha1
+from medperf.utils import get_file_hash
 from medperf.exceptions import CommunicationRetrievalError
 from medperf.tests.mocks.benchmark import TestBenchmark
 from medperf.tests.mocks.dataset import TestDataset
@@ -93,7 +93,7 @@ def generate_cubefile_fn(fs, path, filename):
             fs.create_file(filepath)
         except FileExistsError:
             pass
-        hash = get_file_sha1(filepath)
+        hash = get_file_hash(filepath)
         # special case: tarball file
         if filename == config.tarball_filename:
             return hash

--- a/cli/medperf/tests/test_utils.py
+++ b/cli/medperf/tests/test_utils.py
@@ -114,8 +114,14 @@ def test_get_file_hash_opens_specified_file(mocker, file):
 @pytest.mark.parametrize(
     "file_io",
     [
-        (b"test file\n", "0181d93fee60b818e3f92e470ea97a2aff4ca56a"),
-        (b"file\nwith\nmultilines\n", "a69ce122f95a94dc02485764d463b10545a558c8"),
+        (
+            b"test file\n",
+            "55f8718109829bf506b09d8af615b9f107a266e19f7a311039d1035f180b22d4",
+        ),
+        (
+            b"file\nwith\nmultilines\n",
+            "7361d0aa589a45156d130cfde89f8ad441770fd87d992f404e5758ece6d36b49",
+        ),
     ],
 )
 def test_get_file_hash_calculates_hash(mocker, file_io):
@@ -378,7 +384,7 @@ def test_get_folder_hash_returns_expected_hash(mocker, filesystem):
     hash = utils.get_folder_hash("test")
 
     # Assert
-    assert hash == "4bf17af7fa48c5b03a3315a1f2eb17a301ed883a"
+    assert hash == "b7e9365f1e796ba29e9e6b1b94b5f4cc7238530601fad8ec96ece9fee68c3d7f"
 
 
 @pytest.mark.parametrize(

--- a/cli/medperf/tests/test_utils.py
+++ b/cli/medperf/tests/test_utils.py
@@ -138,7 +138,7 @@ def test_get_file_hash_calculates_hash(mocker, file_io):
 
 @pytest.mark.parametrize(
     "existing_dirs",
-    [config_dirs[0:i] + config_dirs[i + 1 :] for i in range(len(config_dirs))],
+    [config_dirs[0:i] + config_dirs[i + 1:] for i in range(len(config_dirs))],
 )
 def test_init_storage_creates_nonexisting_paths(mocker, existing_dirs):
     # Arrange

--- a/cli/medperf/tests/test_utils.py
+++ b/cli/medperf/tests/test_utils.py
@@ -100,12 +100,12 @@ def test_setup_logging_filters_sensitive_data(text, exp_output, prepare_logs):
 
 
 @pytest.mark.parametrize("file", ["./test.txt", "../file.yaml", "folder/file.zip"])
-def test_get_file_sha1_opens_specified_file(mocker, file):
+def test_get_file_hash_opens_specified_file(mocker, file):
     # Arrange
     spy = mocker.patch("builtins.open", mock_open())
 
     # Act
-    utils.get_file_sha1(file)
+    utils.get_file_hash(file)
 
     # Assert
     spy.assert_called_once_with(file, "rb")
@@ -118,13 +118,13 @@ def test_get_file_sha1_opens_specified_file(mocker, file):
         (b"file\nwith\nmultilines\n", "a69ce122f95a94dc02485764d463b10545a558c8"),
     ],
 )
-def test_get_file_sha1_calculates_hash(mocker, file_io):
+def test_get_file_hash_calculates_hash(mocker, file_io):
     # Arrange
     file_contents, expected_hash = file_io
     mocker.patch("builtins.open", mock_open(read_data=file_contents))
 
     # Act
-    hash = utils.get_file_sha1("")
+    hash = utils.get_file_hash("")
 
     # Assert
     assert hash == expected_hash
@@ -132,7 +132,7 @@ def test_get_file_sha1_calculates_hash(mocker, file_io):
 
 @pytest.mark.parametrize(
     "existing_dirs",
-    [config_dirs[0:i] + config_dirs[i + 1:] for i in range(len(config_dirs))],
+    [config_dirs[0:i] + config_dirs[i + 1 :] for i in range(len(config_dirs))],
 )
 def test_init_storage_creates_nonexisting_paths(mocker, existing_dirs):
     # Arrange
@@ -337,45 +337,45 @@ def test_dict_pretty_print_passes_clean_dict_to_yaml(mocker, ui, dict_with_nones
     spy.assert_called_once_with(exp_dict)
 
 
-def test_get_folder_sha1_hashes_all_files_in_folder(mocker, filesystem):
+def test_get_folder_hash_hashes_all_files_in_folder(mocker, filesystem):
     # Arrange
     fs = filesystem[0]
     files = filesystem[1]
     exp_calls = [call(file) for file in files]
     mocker.patch("os.walk", return_value=fs)
-    spy = mocker.patch(patch_utils.format("get_file_sha1"), side_effect=files)
+    spy = mocker.patch(patch_utils.format("get_file_hash"), side_effect=files)
 
     # Act
-    utils.get_folder_sha1("test")
+    utils.get_folder_hash("test")
 
     # Assert
     spy.assert_has_calls(exp_calls)
 
 
-def test_get_folder_sha1_sorts_individual_hashes(mocker, filesystem):
+def test_get_folder_hash_sorts_individual_hashes(mocker, filesystem):
     # Arrange
     fs = filesystem[0]
     files = filesystem[1]
     mocker.patch("os.walk", return_value=fs)
-    mocker.patch(patch_utils.format("get_file_sha1"), side_effect=files)
+    mocker.patch(patch_utils.format("get_file_hash"), side_effect=files)
     spy = mocker.patch("builtins.sorted", side_effect=sorted)
 
     # Act
-    utils.get_folder_sha1("test")
+    utils.get_folder_hash("test")
 
     # Assert
     spy.assert_called_once_with(files)
 
 
-def test_get_folder_sha1_returns_expected_hash(mocker, filesystem):
+def test_get_folder_hash_returns_expected_hash(mocker, filesystem):
     # Arrange
     fs = filesystem[0]
     files = filesystem[1]
     mocker.patch("os.walk", return_value=fs)
-    mocker.patch(patch_utils.format("get_file_sha1"), side_effect=files)
+    mocker.patch(patch_utils.format("get_file_hash"), side_effect=files)
 
     # Act
-    hash = utils.get_folder_sha1("test")
+    hash = utils.get_folder_hash("test")
 
     # Assert
     assert hash == "4bf17af7fa48c5b03a3315a1f2eb17a301ed883a"

--- a/cli/medperf/tests/utils.py
+++ b/cli/medperf/tests/utils.py
@@ -1,7 +1,7 @@
-from medperf.utils import get_file_sha1
+from medperf.utils import get_file_hash
 
 
 def calculate_fake_file_hash(fs, contents):
     # TODO: should calculate the hash of a string in memory
     fs.create_file("some_file", contents=contents)
-    return get_file_sha1("some_file")
+    return get_file_hash("some_file")

--- a/cli/medperf/utils.py
+++ b/cli/medperf/utils.py
@@ -94,8 +94,8 @@ def base_storage_path(subpath: str):
     return os.path.join(config.storage, subpath)
 
 
-def get_file_sha1(path: str) -> str:
-    """Calculates the sha1 hash for a given file.
+def get_file_hash(path: str) -> str:
+    """Calculates the sha256 hash for a given file.
 
     Args:
         path (str): Location of the file of interest.
@@ -103,18 +103,18 @@ def get_file_sha1(path: str) -> str:
     Returns:
         str: Calculated hash
     """
-    logging.debug("Calculating SHA1 hash for file {}".format(path))
+    logging.debug("Calculating hash for file {}".format(path))
     BUF_SIZE = 65536
-    sha1 = hashlib.sha1()
+    sha = hashlib.sha256()
     with open(path, "rb") as f:
         while True:
             data = f.read(BUF_SIZE)
             if not data:
                 break
-            sha1.update(data)
+            sha.update(data)
 
-    sha_val = sha1.hexdigest()
-    logging.debug(f"SHA1 hash for file {path}: {sha_val}")
+    sha_val = sha.hexdigest()
+    logging.debug(f"Hash for file {path}: {sha_val}")
     return sha_val
 
 
@@ -381,7 +381,7 @@ def combine_proc_sp_text(proc: spawn) -> str:
     return proc_out
 
 
-def get_folder_sha1(path: str) -> str:
+def get_folder_hash(path: str) -> str:
     """Generates a hash for all the contents of the folder. This procedure
     hashes all of the files in the folder, sorts them and then hashes that list.
 
@@ -389,20 +389,20 @@ def get_folder_sha1(path: str) -> str:
         path (str): Folder to hash
 
     Returns:
-        str: sha1 hash of the whole folder
+        str: sha256 hash of the whole folder
     """
     hashes = []
     for root, _, files in os.walk(path, topdown=False):
         for file in files:
             logging.debug(f"Hashing file {file}")
             filepath = os.path.join(root, file)
-            hashes.append(get_file_sha1(filepath))
+            hashes.append(get_file_hash(filepath))
 
     hashes = sorted(hashes)
-    sha1 = hashlib.sha1()
+    sha = hashlib.sha256()
     for hash in hashes:
-        sha1.update(hash.encode("utf-8"))
-    hash_val = sha1.hexdigest()
+        sha.update(hash.encode("utf-8"))
+    hash_val = sha.hexdigest()
     logging.debug(f"Folder hash: {hash_val}")
     return hash_val
 

--- a/server/seed_utils.py
+++ b/server/seed_utils.py
@@ -103,11 +103,11 @@ def create_benchmark(api_server, benchmark_owner_token, admin_token):
         {
             "name": "chestxray_prep",
             "git_mlcube_url": (ASSETS_URL + "data_preparator/mlcube/mlcube.yaml"),
-            "mlcube_hash": "425d1d64c2247e8270ec7159b858ae1cc34d2281",
+            "mlcube_hash": "a12a2d4e4290ffac38846c81d6300a24090605410eb603f02e8905f9674f1abc",
             "git_parameters_url": (
                 ASSETS_URL + "data_preparator/mlcube/workspace/parameters.yaml"
             ),
-            "parameters_hash": "2b28ab34a12e0c0767ea9022ab14e9a0dfba67f2",
+            "parameters_hash": "1541e05437040745d2489e8d2cf14795d4839eecc15c1ac959c84f6b77c1a5df",
             "image_tarball_url": "",
             "image_tarball_hash": "",
             "image_hash": "4cefa8a2b9580220a0503076f1e961e4d86ec72dad8e1e78b9c43444dee9a4cd",
@@ -144,16 +144,16 @@ def create_benchmark(api_server, benchmark_owner_token, admin_token):
         {
             "name": "chestxray_cnn",
             "git_mlcube_url": (ASSETS_URL + "model_custom_cnn/mlcube/mlcube.yaml"),
-            "mlcube_hash": "5e5ca7f0228b2b660f4dc672fa8cc23e28df2df4",
+            "mlcube_hash": "0212a9ed74c71c717b4540c154d56726841d1c7c963cdaceb3542bd42e34bd26",
             "git_parameters_url": (
                 ASSETS_URL + "model_custom_cnn/mlcube/workspace/parameters.yaml"
             ),
-            "parameters_hash": "c5f977a7d1b40d125e6450b3cc0956ea5b0a652c",
+            "parameters_hash": "af0aed4735b5075c198f8b49b3afbf7a0d7eaaaaa2a2b914d5931f0bee51d3f6",
             "additional_files_tarball_url": (
                 "https://storage.googleapis.com/medperf-storage/"
                 "chestxray_tutorial/cnn_weights.tar.gz"
             ),
-            "additional_files_tarball_hash": "6c2346c11a3e5e7afa575bce711eea755266b1ed",
+            "additional_files_tarball_hash": "bff003e244759c3d7c8b9784af0819c7f252da8626745671ccf7f46b8f19a0ca",
             "image_hash": "63d48be95598a7474d1bd26fdee41dcc20a752a436c28b35dbd33796087a6d29",
             "image_tarball_url": "",
             "image_tarball_hash": "",
@@ -188,11 +188,11 @@ def create_benchmark(api_server, benchmark_owner_token, admin_token):
         {
             "name": "chestxray_metrics",
             "git_mlcube_url": (ASSETS_URL + "metrics/mlcube/mlcube.yaml"),
-            "mlcube_hash": "7b3bd8ece694470abf5cb76159d638811d698049",
+            "mlcube_hash": "5dce9b6a1498c0e47a3e7f3167c0157b00ab4445b31e37f61f6eab161d6b3624",
             "git_parameters_url": (
                 ASSETS_URL + "metrics/mlcube/workspace/parameters.yaml"
             ),
-            "parameters_hash": "277598e53d6a75431e9bec610595e8590be5bf01",
+            "parameters_hash": "16cad451c54b801a5b50d999330465d7f68ab5f6d30a0674268d2d17c7f26b73",
             "image_tarball_url": "",
             "image_tarball_hash": "",
             "image_hash": "2dbea6a3ba40d553905427c8bb156f219970306f55061462918fd19b220e9b51",
@@ -231,7 +231,7 @@ def create_benchmark(api_server, benchmark_owner_token, admin_token):
             "description": "benchmark-sample",
             "docs_url": "",
             "demo_dataset_tarball_url": "https://storage.googleapis.com/medperf-storage/chestxray_tutorial/demo_data.tar.gz",
-            "demo_dataset_tarball_hash": "fd54a97f52ebc0e2f533a17b77165ee4d343f5b4",
+            "demo_dataset_tarball_hash": "71faabd59139bee698010a0ae3a69e16d97bc4f2dde799d9e187b94ff9157c00",
             "demo_dataset_generated_uid": "730d2474d8f22340d9da89fa2eb925fcb95683e0",
             "data_preparation_mlcube": data_preprocessor_mlcube,
             "reference_model_mlcube": reference_model_executor_mlcube,
@@ -275,16 +275,16 @@ def create_model(api_server, model_owner_token, benchmark_owner_token, benchmark
         {
             "name": "chestxray_mobilenet",
             "git_mlcube_url": (ASSETS_URL + "model_mobilenetv2/mlcube/mlcube.yaml"),
-            "mlcube_hash": "172a58c365864552d0718e094e9454a2f8eec30f",
+            "mlcube_hash": "5ed783c6aaffe813a82ba61e8d7de986aeedae92662ff76288b142968732aad7",
             "git_parameters_url": (
                 ASSETS_URL + "model_mobilenetv2/mlcube/workspace/parameters.yaml"
             ),
-            "parameters_hash": "b36a5bbf9cbdad8be232840e040235918e98a2c6",
+            "parameters_hash": "81a7e5c2006a8f54c4c2bd16d751df44d3cde3feb1a0c12768df095744a76c60",
             "additional_files_tarball_url": (
                 "https://storage.googleapis.com/medperf-storage/"
                 "chestxray_tutorial/mobilenetv2_weights.tar.gz"
             ),
-            "additional_files_tarball_hash": "b99eb6d11a141e32333389d234e819da7a409c17",
+            "additional_files_tarball_hash": "771f67bba92a11c83d16a522f0ba1018020ff758e2277d33f49056680c788892",
             "image_tarball_url": "",
             "image_tarball_hash": "",
             "image_hash": "7ae4a8ecbe899b5486c699d934d74bce7f3aa73d779e0138e6d119cd8040b46e",


### PR DESCRIPTION
This PR replaces `sha1` with `sha256` as the latter is considered more robust against collision attacks.