### PR TITLE
Inspect image hash from file

### DIFF
--- a/cli/medperf/tests/entities/test_cube.py
+++ b/cli/medperf/tests/entities/test_cube.py
@@ -39,7 +39,7 @@ def setup(request, mocker, comms, fs):
     request.param["uploaded"] = uploaded
 
     # Mock additional third party elements
-    mpexpect = MockPexpect(0, "image_hash")
+    mpexpect = MockPexpect(0)
     mocker.patch(PATCH_CUBE.format("pexpect.spawn"), side_effect=mpexpect.spawn)
     mocker.patch(PATCH_CUBE.format("combine_proc_sp_text"), return_value="")
 
@@ -78,13 +78,19 @@ class TestGetFiles:
             assert os.path.exists(file) and os.path.isfile(file)
 
     @pytest.mark.parametrize("setup", [{"remote": [NO_IMG_CUBE]}], indirect=True)
-    def test_get_cube_without_image_configures_mlcube(self, mocker, setup):
+    def test_get_cube_without_image_configures_mlcube(self, mocker, setup, fs):
         # Arrange
+        tmp_path = "tmp_path"
+        mocker.patch(PATCH_CUBE.format("generate_tmp_path"), return_value=tmp_path)
+        # This is the side effect of mlcube inspect
+        fs.create_file(
+            "tmp_path", contents=yaml.dump({"hash": NO_IMG_CUBE["image_hash"]})
+        )
         spy = mocker.spy(medperf.entities.cube.pexpect, "spawn")
-        mocker.patch(PATCH_CUBE.format("verify_hash"), return_value=True)
         expected_cmds = [
             f"mlcube configure --mlcube={self.manifest_path}",
-            f"mlcube inspect --mlcube={self.manifest_path} --format=yaml",
+            f"mlcube inspect --mlcube={self.manifest_path}"
+            f" --format=yaml --output-file {tmp_path}",
         ]
         expected_cmds = [call(cmd, timeout=None) for cmd in expected_cmds]
 
@@ -95,10 +101,12 @@ class TestGetFiles:
         spy.assert_has_calls(expected_cmds)
 
     @pytest.mark.parametrize("setup", [{"remote": [NO_IMG_CUBE]}], indirect=True)
-    def test_get_cube_without_image_fails_with_wrong_hash(self, mocker, setup):
-        # By default, the mocked object will not return a hash
-        # This means we would be comparing wrong hashes
-        mocker.spy(medperf.entities.cube.pexpect, "spawn")
+    def test_get_cube_without_image_fails_with_wrong_hash(self, mocker, setup, fs):
+        # Arrange
+        tmp_path = "tmp_path"
+        mocker.patch(PATCH_CUBE.format("generate_tmp_path"), return_value=tmp_path)
+        # This is the side effect of mlcube inspect
+        fs.create_file("tmp_path", contents=yaml.dump({"hash": "invalid hash"}))
 
         # Act & Assert
         with pytest.raises(InvalidEntityError):

--- a/cli/medperf/tests/mocks/pexpect.py
+++ b/cli/medperf/tests/mocks/pexpect.py
@@ -1,6 +1,3 @@
-import yaml
-
-
 class MockChild:
     def __init__(self, exitstatus, stdout):
         self.exitstatus = exitstatus

--- a/cli/medperf/tests/mocks/pexpect.py
+++ b/cli/medperf/tests/mocks/pexpect.py
@@ -2,15 +2,15 @@ import yaml
 
 
 class MockChild:
-    def __init__(self, exitstatus, hash):
+    def __init__(self, exitstatus, stdout):
         self.exitstatus = exitstatus
-        self.inspect = yaml.dump({"hash": hash})
+        self.stdout = stdout
 
     def __enter__(self, *args, **kwargs):
         return self
 
     def read(self):
-        return self.inspect
+        return self.stdout
 
     def __exit__(self, *args, **kwargs):
         self.close()
@@ -23,9 +23,9 @@ class MockChild:
 
 
 class MockPexpect:
-    def __init__(self, exitstatus, hash):
+    def __init__(self, exitstatus, stdout=""):
         self.exitstatus = exitstatus
-        self.hash = hash
+        self.stdout = stdout
 
     def spawn(self, command: str, timeout: int = 30) -> MockChild:
-        return MockChild(self.exitstatus, self.hash)
+        return MockChild(self.exitstatus, self.stdout)

--- a/cli/requirements.txt
+++ b/cli/requirements.txt
@@ -10,9 +10,9 @@ colorama==0.4.4
 time-machine==2.4.0
 pytest-mock==1.13.0
 pyfakefs==5.0.0
-mlcube @ git+https://github.com/mlcommons/mlcube@fb371c960938b495e939bf38b161199d529cf912#subdirectory=mlcube
-mlcube-docker @ git+https://github.com/mlcommons/mlcube@fb371c960938b495e939bf38b161199d529cf912#subdirectory=runners/mlcube_docker
-mlcube-singularity @ git+https://github.com/mlcommons/mlcube@fb371c960938b495e939bf38b161199d529cf912#subdirectory=runners/mlcube_singularity
+mlcube @ git+https://github.com/mlcommons/mlcube@755d388edc9fb32dfa2b09c244252485b2b554b3#subdirectory=mlcube
+mlcube-docker @ git+https://github.com/mlcommons/mlcube@755d388edc9fb32dfa2b09c244252485b2b554b3#subdirectory=runners/mlcube_docker
+mlcube-singularity @ git+https://github.com/mlcommons/mlcube@755d388edc9fb32dfa2b09c244252485b2b554b3#subdirectory=runners/mlcube_singularity
 validators==0.18.2
 merge-args==0.1.4
 synapseclient==2.7.0


### PR DESCRIPTION
This PR enhances how MedPerf inspects the MLCube's docker image hash by reading the hash from a tmp file instead of parsing the STDOUT of the mlcube process.

This makes this step robust against cases where mlcube process might print unexpected info in addition to the yaml string.