### PR TITLE
Persist Predictions Storage

### DIFF
--- a/cli/cli_tests.sh
+++ b/cli/cli_tests.sh
@@ -235,9 +235,9 @@ checkFailed "Model3 association failed"
 echo "\n"
 
 ##########################################################
-echo "====================================="
-echo "Running failing model association"
-echo "====================================="
+echo "======================================================"
+echo "Running failing model association (This will NOT fail)"
+echo "======================================================"
 medperf mlcube associate -m $FAILING_MODEL_UID -b $BMK_UID -y
 checkFailed "Failing model association failed"
 ##########################################################
@@ -309,9 +309,23 @@ checkFailed "run all outstanding models failed"
 echo "\n"
 
 ##########################################################
-echo "====================================="
-echo "Run failing cube with ignore errors"
-echo "====================================="
+echo "======================================================================================"
+echo "Run failing cube with ignore errors (This SHOULD fail since predictions folder exists)"
+echo "======================================================================================"
+medperf run -b $BMK_UID -d $DSET_A_UID -m $FAILING_MODEL_UID -y --ignore-model-errors
+if [ "$?" -eq 0 ]; then
+  i_am_a_command_that_does_not_exist_and_hence_changes_the_last_exit_status_to_nonzero
+fi
+checkFailed "MLCube ran successfuly but should fail since predictions folder exists"
+##########################################################
+
+echo "\n"
+
+##########################################################
+echo "====================================================================="
+echo "Run failing cube with ignore errors after deleting predictions folder"
+echo "====================================================================="
+rm -rf $MEDPERF_SUBSTORAGE/predictions/model-fail/$DSET_A_GENUID
 medperf run -b $BMK_UID -d $DSET_A_UID -m $FAILING_MODEL_UID -y --ignore-model-errors
 checkFailed "Failing mlcube run with ignore errors failed"
 ##########################################################

--- a/cli/medperf/commands/execution.py
+++ b/cli/medperf/commands/execution.py
@@ -3,7 +3,7 @@ import logging
 
 from medperf.entities.cube import Cube
 from medperf.entities.dataset import Dataset
-from medperf.utils import remove_path, generate_tmp_path, storage_path
+from medperf.utils import generate_tmp_path, storage_path
 import medperf.config as config
 from medperf.exceptions import ExecutionError
 import yaml

--- a/cli/medperf/commands/execution.py
+++ b/cli/medperf/commands/execution.py
@@ -27,7 +27,6 @@ class Execution:
             execution.run_inference()
             execution.run_evaluation()
         execution_summary = execution.todict()
-        execution.store_predictions()
         return execution_summary
 
     def __init__(
@@ -42,10 +41,23 @@ class Execution:
 
     def prepare(self):
         self.partial = False
-        self.preds_path = generate_tmp_path()
+        self.preds_path = self.__setup_predictions_path()
         self.results_path = generate_tmp_path()
-        logging.debug(f"tmp predictions output: {self.preds_path}")
         logging.debug(f"tmp results output: {self.results_path}")
+
+    def __setup_predictions_path(self):
+        model_uid = self.model.generated_uid
+        data_hash = self.dataset.generated_uid
+        preds_path = os.path.join(
+            config.predictions_storage, str(model_uid), str(data_hash)
+        )
+        preds_path = storage_path(preds_path)
+        if os.path.exists(preds_path):
+            msg = f"Found existing predictions for model {self.model.id} on dataset "
+            msg += f"{self.dataset.id} at {preds_path}. Consider deleting this "
+            msg += "folder if you wish to overwrite the predictions."
+            raise ExecutionError(msg)
+        return preds_path
 
     def run_inference(self):
         self.ui.text = "Running model inference on dataset"
@@ -103,17 +115,3 @@ class Execution:
         with open(self.results_path, "r") as f:
             results = yaml.safe_load(f)
         return results
-
-    def store_predictions(self):
-        model_uid = self.model.generated_uid
-        data_hash = self.dataset.generated_uid
-        new_preds_path = os.path.join(
-            config.predictions_storage, str(model_uid), str(data_hash)
-        )
-        new_preds_path = storage_path(new_preds_path)
-        remove_path(new_preds_path)
-        # NOTE: currently prediction are overwritten if found.
-        # when we start caring about storing predictions for use after
-        # result creation, we should change this
-        os.makedirs(new_preds_path)
-        os.rename(self.preds_path, new_preds_path)

--- a/cli/medperf/tests/commands/test_execution.py
+++ b/cli/medperf/tests/commands/test_execution.py
@@ -1,8 +1,10 @@
+import os
 from unittest.mock import ANY, call
 from medperf.commands.execution import Execution
 from medperf.exceptions import ExecutionError
 from medperf.tests.mocks.cube import TestCube
 from medperf.tests.mocks.dataset import TestDataset
+from medperf.utils import storage_path
 import pytest
 from medperf import config
 import yaml
@@ -50,7 +52,6 @@ def setup(request, mocker, ui, fs):
         "failing_model": False,
         "failing_eval": False,
         "execution_results": {"res": 1, "metric": 55},
-        "preds_path": "tmp_preds_path",
         "result_path": "tmp_result_path",
     }
     state_variables.update(request.param)
@@ -61,7 +62,7 @@ def setup(request, mocker, ui, fs):
 
     mocker.patch(
         PATCH_EXECUTION.format("generate_tmp_path"),
-        side_effect=[state_variables["preds_path"], state_variables["result_path"]],
+        return_value=state_variables["result_path"],
     )
     spies = {
         "model_run": model_run_spy,
@@ -96,6 +97,27 @@ class TestFailures:
             INPUT_DATASET, INPUT_MODEL, INPUT_EVALUATOR, ignore_model_errors=True
         )
 
+    @pytest.mark.parametrize("setup", [{}], indirect=True)
+    @pytest.mark.parametrize("ignore_model_errors", [True, False])
+    def test_failure_with_existing_predictions(mocker, setup, ignore_model_errors, fs):
+        # Arrange
+        preds_path = storage_path(
+            os.path.join(
+                config.predictions_storage,
+                INPUT_MODEL.generated_uid,
+                INPUT_DATASET.generated_uid,
+            )
+        )
+        fs.create_dir(preds_path)
+        # Act & Assert
+        with pytest.raises(ExecutionError):
+            Execution.run(
+                INPUT_DATASET,
+                INPUT_MODEL,
+                INPUT_EVALUATOR,
+                ignore_model_errors=ignore_model_errors,
+            )
+
 
 @pytest.mark.parametrize("setup", [{"failing_model": True}], indirect=True)
 def test_partial_result_when_ignore_error_and_failing_model(mocker, setup):
@@ -127,18 +149,24 @@ def test_results_are_returned(mocker, setup):
 @pytest.mark.parametrize("setup", [{}], indirect=True)
 def test_cube_run_are_called_properly(mocker, setup):
     # Arrange
-    state_variables = setup[0]
+    exp_preds_path = storage_path(
+        os.path.join(
+            config.predictions_storage,
+            INPUT_MODEL.generated_uid,
+            INPUT_DATASET.generated_uid,
+        )
+    )
     exp_model_call = call(
         task="infer",
         timeout=config.infer_timeout,
         data_path=INPUT_DATASET.data_path,
-        output_path=state_variables["preds_path"],
+        output_path=exp_preds_path,
         string_params={"Ptasks.infer.parameters.input.data_path.opts": "ro"},
     )
     exp_eval_call = call(
         task="evaluate",
         timeout=config.evaluate_timeout,
-        predictions=state_variables["preds_path"],
+        predictions=exp_preds_path,
         labels=INPUT_DATASET.labels_path,
         output_path=ANY,
         string_params={


### PR DESCRIPTION
Predictions from now on will always be kept in the medperf storage even if the model fails or the metrics fails. Also, the client will not overwrite predictions if found; it will exit and ask the user to remove the folder (This to be changed for a smoother interaction).