### PR TITLE
[fix] Add note about docker images to be pushed to Synapse

### DIFF
--- a/docs/mlcubes/mlcube_models.md
+++ b/docs/mlcubes/mlcube_models.md
@@ -58,6 +58,8 @@ docker_image_name [docker/image:latest]: # (6)!
 5. Indicates how many GPUs should be visible by the MLCube.
 6. MLCubes use Docker containers under the hood. Here, you can provide an image tag to the image that will be created by this MLCube. **You should use a valid name that allows you to upload it to a Docker registry.**
 
+!!!Note If you are creating a MLCube to submit on the [Synapse.org platform](https://www.synapse.org/#), you must prefix the Docker image name with: `docker.synapse.org/<project synID>/`, where `<project synID>` is the ID of your Synapse project. For example, if your Synapse project ID is syn12345, then a potential `docker_image_name` could be: `docker.synapse.org/syn12345/my-model` or `docker.synapse.org/syn12345/brats2023`
+
 After filling the configuration options, the following directory structure will be generated:
 
 ```bash


### PR DESCRIPTION
## Proposed change

A trending issue we came across in the BraTS 2023 challenge was that the config file did not contain the correct Docker image name, and so, I was not able to run some MLCubes in a timely manner.  To help alleviate this issue for BraTS 2024 and future Synapse-hosted challenges utilizing MedPerf, I suggest a note is added to the docs about the naming expectations for `docker_image_name` for MLCubes to be submitted on Synapse.

Feel free to expand and/or update the added note as you see fit.

Thanks!