### PR TITLE
Mlcube download logging

### DIFF
--- a/cli/medperf/tests/entities/test_cube.py
+++ b/cli/medperf/tests/entities/test_cube.py
@@ -96,6 +96,12 @@ class TestGetFiles:
         # Act
         Cube.get(self.id)
 
+        # During cube downloading, we pass `env` variable that contains all ENVs from medperf process.
+        # as this is dynamic variable, we don't bother about what is passed there; so we do not want to test it.
+        # Thus, we just remove passed `env` from executed calls, for it not to intersect assertion
+        for executed_call in spy.mock_calls:
+            if 'env' in executed_call.kwargs:
+                executed_call.kwargs.pop('env')
         # Assert
         spy.assert_has_calls(expected_cmds)
 

--- a/cli/medperf/tests/mocks/pexpect.py
+++ b/cli/medperf/tests/mocks/pexpect.py
@@ -18,11 +18,13 @@ class MockChild:
     def close(self):
         pass
 
+    def expect(self, ch):
+        pass
 
 class MockPexpect:
     def __init__(self, exitstatus, stdout=""):
         self.exitstatus = exitstatus
         self.stdout = stdout
 
-    def spawn(self, command: str, timeout: int = 30) -> MockChild:
+    def spawn(self, command: str, timeout: int = 30, env: dict = None) -> MockChild:
         return MockChild(self.exitstatus, self.stdout)

--- a/cli/medperf/tests/mocks/pexpect.py
+++ b/cli/medperf/tests/mocks/pexpect.py
@@ -21,6 +21,7 @@ class MockChild:
     def expect(self, ch):
         pass
 
+
 class MockPexpect:
     def __init__(self, exitstatus, stdout=""):
         self.exitstatus = exitstatus

--- a/cli/medperf/ui/stdin.py
+++ b/cli/medperf/ui/stdin.py
@@ -40,3 +40,6 @@ class StdIn(UI):
 
     def hidden_prompt(self, msg: str) -> str:
         return self.prompt(msg)
+
+    def print_highlight(self, msg: str = ""):
+        self.print(msg)

--- a/cli/medperf/utils.py
+++ b/cli/medperf/utils.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import re
 import os
+import sys
 import yaml
 import random
 import hashlib
@@ -243,6 +244,21 @@ def combine_proc_sp_text(proc: spawn) -> str:
             ui.text = static_text
 
     return proc_out
+
+
+class DebugAndOutputLogger(object):
+    """
+    Prints the output both to stderr (directly) and to debug log
+    """
+    def write(self, byte):
+        s = byte.decode("utf-8")
+        sys.stdout.write(s)
+        sys.stdout.flush()
+
+        logging.debug(s.rstrip('\n'))
+
+    def flush(self):
+        sys.stdout.flush()
 
 
 def get_folders_hash(paths: List[str]) -> str:

--- a/cli/medperf/utils.py
+++ b/cli/medperf/utils.py
@@ -250,9 +250,15 @@ class DebugAndOutputLogger(object):
     """
     Prints the output both to stderr (directly) and to debug log
     """
+    def __init__(self):
+        self._just_started_flag = True
+
     def write(self, byte):
+        if self._just_started_flag:
+            sys.stdout.write("\r\033[K")  # clean the current spinner line
+            self._just_started_flag = False
         s = byte.decode("utf-8")
-        sys.stdout.write(s)
+        sys.stdout.write(f'{Fore.WHITE}{Style.DIM}{s}{Style.RESET_ALL}')
         sys.stdout.flush()
 
         logging.debug(s.rstrip('\n'))

--- a/cli/medperf/utils.py
+++ b/cli/medperf/utils.py
@@ -254,10 +254,10 @@ class DebugAndOutputLogger(object):
         self._just_started_flag = True
 
     def write(self, byte):
-        if self._just_started_flag:
+        s = byte.decode("utf-8")
+        if self._just_started_flag or s == '\n':
             sys.stdout.write("\r\033[K")  # clean the current spinner line
             self._just_started_flag = False
-        s = byte.decode("utf-8")
         sys.stdout.write(f'{Fore.WHITE}{Style.DIM}{s}{Style.RESET_ALL}')
         sys.stdout.flush()
 


### PR DESCRIPTION
Catches `docker pull` output and put it directly to medperf's stdout:
![image](https://github.com/mlcommons/medperf/assets/6936665/3b3fdb47-f1ea-4684-9315-f9bb67a93284)
The result is a bit weird, but at least it shows the `docker pull` is running and smth is executing