### PR TITLE
Singularity support, refactor cube.download

### DIFF
--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -18,6 +18,7 @@ jobs:
         python-version: '3.9'
 
     - name: Install Singularity
+      working-directory: ..
       run: |
         sudo apt-get update
         sudo apt-get install -y build-essential libssl-dev uuid-dev libgpgme11-dev \

--- a/.github/workflows/local-ci.yml
+++ b/.github/workflows/local-ci.yml
@@ -23,9 +23,9 @@ jobs:
         wget https://go.dev/dl/go1.17.11.linux-amd64.tar.gz
         sudo tar --directory=/usr/local -xzvf go1.17.11.linux-amd64.tar.gz
         export PATH=/usr/local/go/bin:$PATH
-        wget https://github.com/sylabs/singularity/releases/download/v3.10.1/singularity-ce-3.10.1.tar.gz
-        tar -xzvf singularity-ce-3.10.1.tar.gz
-        cd singularity-ce-3.10.1
+        wget https://github.com/sylabs/singularity/releases/download/v3.10.0/singularity-ce-3.10.0.tar.gz
+        tar -xzvf singularity-ce-3.10.0.tar.gz
+        cd singularity-ce-3.10.0
         ./mconfig
         cd builddir
         make

--- a/.github/workflows/local-ci.yml
+++ b/.github/workflows/local-ci.yml
@@ -26,9 +26,6 @@ jobs:
         wget https://github.com/sylabs/singularity/releases/download/v3.10.1/singularity-ce-3.10.1.tar.gz
         tar -xzvf singularity-ce-3.10.1.tar.gz
         cd singularity-ce-3.10.1
-        echo "FOR DEBUGGING"
-        sh scripts/get-version
-        echo "END FOR DEBUGGING"
         ./mconfig
         cd builddir
         make

--- a/.github/workflows/local-ci.yml
+++ b/.github/workflows/local-ci.yml
@@ -16,6 +16,9 @@ jobs:
         python-version: '3.9'
 
     - name: Install Singularity
+      # The way we install singularity shouldn't happen inside another git repo, otherwise
+      # the singularity installer will set that repo's tag/commit as the singularity version.
+      working-directory: ..
       run: |
         sudo apt-get update
         sudo apt-get install -y build-essential libssl-dev uuid-dev libgpgme11-dev \

--- a/.github/workflows/local-ci.yml
+++ b/.github/workflows/local-ci.yml
@@ -26,6 +26,9 @@ jobs:
         wget https://github.com/sylabs/singularity/releases/download/v3.10.1/singularity-ce-3.10.1.tar.gz
         tar -xzvf singularity-ce-3.10.1.tar.gz
         cd singularity-ce-3.10.1
+        echo "FOR DEBUGGING"
+        sh scripts/get-version
+        echo "END FOR DEBUGGING"
         ./mconfig
         cd builddir
         make

--- a/.github/workflows/local-ci.yml
+++ b/.github/workflows/local-ci.yml
@@ -23,9 +23,9 @@ jobs:
         wget https://go.dev/dl/go1.17.11.linux-amd64.tar.gz
         sudo tar --directory=/usr/local -xzvf go1.17.11.linux-amd64.tar.gz
         export PATH=/usr/local/go/bin:$PATH
-        wget https://github.com/sylabs/singularity/releases/download/v3.10.0/singularity-ce-3.10.0.tar.gz
-        tar -xzvf singularity-ce-3.10.0.tar.gz
-        cd singularity-ce-3.10.0
+        wget https://github.com/sylabs/singularity/releases/download/v3.10.1/singularity-ce-3.10.1.tar.gz
+        tar -xzvf singularity-ce-3.10.1.tar.gz
+        cd singularity-ce-3.10.1
         ./mconfig
         cd builddir
         make

--- a/cli/cli_chestxray_tutorial_test.sh
+++ b/cli/cli_chestxray_tutorial_test.sh
@@ -4,10 +4,6 @@
 ##########################################################
 ################### Start Testing ########################
 ##########################################################
-# debugging tmp. TODO: remove me
-singularity --version
-singularity version
-which singularity
 
 echo "====================================="
 echo "Retrieving mock dataset"

--- a/cli/cli_chestxray_tutorial_test.sh
+++ b/cli/cli_chestxray_tutorial_test.sh
@@ -4,6 +4,10 @@
 ##########################################################
 ################### Start Testing ########################
 ##########################################################
+# debugging tmp. TODO: remove me
+singularity --version
+singularity version
+which singularity
 
 echo "====================================="
 echo "Retrieving mock dataset"

--- a/cli/cli_tests.sh
+++ b/cli/cli_tests.sh
@@ -243,7 +243,6 @@ echo "====================================="
 #   1) an already built singularity image (model 3)
 #   2) a docker image to be converted (metrics)
 medperf --platform singularity mlcube associate -m $MODEL3_UID -b $BMK_UID -y
-medperf mlcube associate -m $MODEL3_UID -b $BMK_UID -y
 checkFailed "Model3 association failed"
 ##########################################################
 

--- a/cli/cli_tests.sh
+++ b/cli/cli_tests.sh
@@ -107,6 +107,7 @@ medperf mlcube submit --name model2 -m $MODEL_MLCUBE -p $MODEL2_PARAMS -a $MODEL
 checkFailed "Model2 submission failed"
 MODEL2_UID=$(medperf mlcube ls | tail -n 1 | tr -s ' ' | cut -d ' ' -f 2)
 
+# MLCube with singularity section
 medperf mlcube submit --name model3 -m $MODEL_WITH_SINGULARITY -p $MODEL3_PARAMS -a $MODEL_ADD -i $MODEL_SING_IMAGE
 checkFailed "Model3 submission failed"
 MODEL3_UID=$(medperf mlcube ls | tail -n 1 | tr -s ' ' | cut -d ' ' -f 2)
@@ -236,10 +237,12 @@ echo "\n"
 
 ##########################################################
 echo "====================================="
-echo "Running model3 association"
+echo "Running model3 association (with singularity)"
 echo "====================================="
-# medperf --platform singularity mlcube associate -m $MODEL3_UID -b $BMK_UID -y
-# TMP: revert to singularity when MLCube issue is fixed
+# this will run two types of singularity mlcubes:
+#   1) an already built singularity image (model 3)
+#   2) a docker image to be converted (metrics)
+medperf --platform singularity mlcube associate -m $MODEL3_UID -b $BMK_UID -y
 medperf mlcube associate -m $MODEL3_UID -b $BMK_UID -y
 checkFailed "Model3 association failed"
 ##########################################################

--- a/cli/cli_tests.sh
+++ b/cli/cli_tests.sh
@@ -314,10 +314,10 @@ echo "\n"
 
 ##########################################################
 echo "====================================="
-echo "Running model2"
+echo "Running model3 (with singularity)"
 echo "====================================="
-medperf run -b $BMK_UID -d $DSET_A_UID -m $MODEL2_UID -y
-checkFailed "Model2 run failed"
+medperf --platform=singularity run -b $BMK_UID -d $DSET_A_UID -m $MODEL3_UID -y
+checkFailed "Model3 run failed"
 ##########################################################
 
 echo "\n"

--- a/cli/medperf/commands/compatibility_test/utils.py
+++ b/cli/medperf/commands/compatibility_test/utils.py
@@ -95,5 +95,6 @@ def prepare_cube(cube_uid: str):
 def get_cube(uid: int, name: str, local_only: bool = False) -> Cube:
     config.ui.text = f"Retrieving {name} cube"
     cube = Cube.get(uid, local_only=local_only)
+    cube.download_run_files()
     config.ui.print(f"> {name} cube download complete")
     return cube

--- a/cli/medperf/commands/dataset/create.py
+++ b/cli/medperf/commands/dataset/create.py
@@ -96,6 +96,7 @@ class DataPreparation:
             self.ui.print(f"Benchmark Data Preparation: {benchmark.name}")
         self.ui.text = "Retrieving data preparation cube"
         self.cube = Cube.get(cube_uid)
+        self.cube.download_run_files()
         self.ui.print("> Preparation cube download complete")
 
     def run_cube_tasks(self):

--- a/cli/medperf/commands/mlcube/submit.py
+++ b/cli/medperf/commands/mlcube/submit.py
@@ -31,7 +31,8 @@ class SubmitCube:
         config.tmp_paths.append(self.cube.path)
 
     def download(self):
-        self.cube.download()
+        self.cube.download_config_files()
+        self.cube.download_run_files()
 
     def upload(self):
         updated_body = self.cube.upload()

--- a/cli/medperf/commands/result/create.py
+++ b/cli/medperf/commands/result/create.py
@@ -153,6 +153,7 @@ class BenchmarkExecution:
     def __get_cube(self, uid: int, name: str) -> Cube:
         self.ui.text = f"Retrieving {name} cube"
         cube = Cube.get(uid)
+        cube.download_run_files()
         self.ui.print(f"> {name} cube download complete")
         return cube
 

--- a/cli/medperf/decorators.py
+++ b/cli/medperf/decorators.py
@@ -198,9 +198,13 @@ def add_inline_parameters(func: Callable) -> Callable:
             "--gpus",
             help="""
             What GPUs to expose to MLCube.
-            Accepted Values are comma separated GPU IDs (e.g "1,2"), or \"all\".
-            MLCubes that aren't configured to use GPUs won't be affected by this.
-            Defaults to all available GPUs""",
+            Accepted Values are:\n
+            - "" or 0: to expose no GPUs (e.g.: --gpus="")\n
+            - "all": to expose all GPUs. (e.g.: --gpus=all)\n
+            - an integer: to expose a certain number of GPUs. ONLY AVAILABLE FOR DOCKER
+            (e.g., --gpus=2 to expose 2 GPUs)\n
+            - Form "device=<id1>,<id2>": to expose specific GPUs.
+            (e.g., --gpus="device=0,2")\n""",
         ),
         cleanup: bool = typer.Option(
             config.cleanup,

--- a/cli/medperf/entities/cube.py
+++ b/cli/medperf/entities/cube.py
@@ -211,41 +211,63 @@ class Cube(Entity, Uploadable, MedperfSchema, DeployableSchema):
     def download_image(self):
         url = self.image_tarball_url
         tarball_hash = self.image_tarball_hash
-        img_hash = self.image_hash
 
         if url:
             _, local_hash = resources.get_cube_image(url, self.path, tarball_hash)
             self.image_tarball_hash = local_hash
         else:
-            # Retrieve image from image registry
-            logging.debug(f"Retrieving {self.id} image")
-            cmd = f"mlcube configure --mlcube={self.cube_path}"
-            with pexpect.spawn(cmd, timeout=config.mlcube_configure_timeout) as proc:
-                proc_out = proc.read()
-            if proc.exitstatus != 0:
-                raise ExecutionError(
-                    "There was an error while retrieving the MLCube image"
-                )
-            logging.debug(proc_out)
+            if config.platform == "docker":
+                # For docker, image should be pulled before calculating its hash
+                self._get_image_from_registry()
+                self._set_image_hash_from_registry()
+            elif config.platform == "singularity":
+                # For singularity, we need the hash first before trying to convert
+                self._set_image_hash_from_registry()
 
-            # Retrieve image hash from MLCube
-            logging.debug(f"Retrieving {self.id} image hash")
-            tmp_out_yaml = generate_tmp_path()
-            cmd = f"mlcube inspect --mlcube={self.cube_path} --format=yaml"
-            cmd += f" --output-file {tmp_out_yaml}"
-            with pexpect.spawn(cmd, timeout=config.mlcube_inspect_timeout) as proc:
-                proc_stdout = proc.read()
-            logging.debug(proc_stdout)
-            if proc.exitstatus != 0:
-                raise ExecutionError(
-                    "There was an error while inspecting the image hash"
-                )
-            with open(tmp_out_yaml) as f:
-                mlcube_details = yaml.safe_load(f)
-            remove_path(tmp_out_yaml)
-            local_hash = mlcube_details["hash"]
-            verify_hash(local_hash, img_hash)
-            self.image_hash = local_hash
+                image_folder = os.path.join(config.cubes_folder, config.image_path)
+                for file in os.listdir(image_folder):
+                    if file == self._converted_singularity_image_name:
+                        return
+                    remove_path(os.path.join(image_folder, file))
+
+                self._get_image_from_registry()
+            else:
+                # TODO: such a check should happen on commands entrypoints, not here
+                raise InvalidArgumentError("Unsupported platform")
+
+    @property
+    def _converted_singularity_image_name(self):
+        return f"{self.image_hash}.sif"
+
+    def _set_image_hash_from_registry(self):
+        # Retrieve image hash from MLCube
+        logging.debug(f"Retrieving {self.id} image hash")
+        tmp_out_yaml = generate_tmp_path()
+        cmd = f"mlcube inspect --mlcube={self.cube_path} --format=yaml"
+        cmd += f" --platform={config.platform} --output-file {tmp_out_yaml}"
+        with pexpect.spawn(cmd, timeout=config.mlcube_inspect_timeout) as proc:
+            proc_stdout = proc.read()
+        logging.debug(proc_stdout)
+        if proc.exitstatus != 0:
+            raise ExecutionError("There was an error while inspecting the image hash")
+        with open(tmp_out_yaml) as f:
+            mlcube_details = yaml.safe_load(f)
+        remove_path(tmp_out_yaml)
+        local_hash = mlcube_details["hash"]
+        verify_hash(local_hash, self.image_hash)
+        self.image_hash = local_hash
+
+    def _get_image_from_registry(self):
+        # Retrieve image from image registry
+        logging.debug(f"Retrieving {self.id} image")
+        cmd = f"mlcube configure --mlcube={self.cube_path} --platform={config.platform}"
+        if config.platform == "singularity":
+            cmd += f" -Psingularity.image={self._converted_singularity_image_name}"
+        with pexpect.spawn(cmd, timeout=config.mlcube_configure_timeout) as proc:
+            proc_out = proc.read()
+        if proc.exitstatus != 0:
+            raise ExecutionError("There was an error while retrieving the MLCube image")
+        logging.debug(proc_out)
 
     def download_config_files(self):
         try:
@@ -300,12 +322,32 @@ class Cube(Entity, Uploadable, MedperfSchema, DeployableSchema):
             cmd_arg = f'{k}="{v}"'
             cmd = " ".join([cmd, cmd_arg])
 
-        cpu_args = self.get_config("docker.cpu_args") or ""
-        gpu_args = self.get_config("docker.gpu_args") or ""
-        cpu_args = " ".join([cpu_args, "-u $(id -u):$(id -g)"]).strip()
-        gpu_args = " ".join([gpu_args, "-u $(id -u):$(id -g)"]).strip()
-        cmd += f' -Pdocker.cpu_args="{cpu_args}"'
-        cmd += f' -Pdocker.gpu_args="{gpu_args}"'
+        # TODO: we should override run args instead of what we are doing below
+        #       we shouldn't allow arbitrary run args unless our client allows it
+        if config.platform == "docker":
+            # use current user
+            cpu_args = self.get_config("docker.cpu_args") or ""
+            gpu_args = self.get_config("docker.gpu_args") or ""
+            cpu_args = " ".join([cpu_args, "-u $(id -u):$(id -g)"]).strip()
+            gpu_args = " ".join([gpu_args, "-u $(id -u):$(id -g)"]).strip()
+            cmd += f' -Pdocker.cpu_args="{cpu_args}"'
+            cmd += f' -Pdocker.gpu_args="{gpu_args}"'
+        elif config.platform == "singularity":
+            # use -e to discard host env vars, -C to isolate the container (see singularity run --help)
+            run_args = self.get_config("singularity.run_args") or ""
+            run_args = " ".join([run_args, "-eC"]).strip()
+            cmd += f' -Psingularity.run_args="{run_args}"'
+
+            # set image name in case of running docker image with singularity
+            # Assuming we only accept mlcube.yamls with either singularity or docker sections
+            # TODO: make checks on submitted mlcubes
+            singularity_config = self.get_config("singularity")
+            if singularity_config is None:
+                cmd += (
+                    f' -Psingularity.image="{self._converted_singularity_image_name}"'
+                )
+        else:
+            raise InvalidArgumentError("Unsupported platform")
 
         logging.info(f"Running MLCube command: {cmd}")
         proc = pexpect.spawn(cmd, timeout=timeout)

--- a/cli/medperf/entities/cube.py
+++ b/cli/medperf/entities/cube.py
@@ -249,6 +249,7 @@ class Cube(Entity, Uploadable, MedperfSchema, DeployableSchema):
         with pexpect.spawn(cmd, timeout=config.mlcube_inspect_timeout) as proc:
             proc_stdout = proc.read()
         logging.debug(proc_stdout)
+        print(proc_stdout)
         if proc.exitstatus != 0:
             raise ExecutionError("There was an error while inspecting the image hash")
         with open(tmp_out_yaml) as f:

--- a/cli/medperf/entities/cube.py
+++ b/cli/medperf/entities/cube.py
@@ -167,7 +167,7 @@ class Cube(Entity, Uploadable, MedperfSchema, DeployableSchema):
 
         if not cube.is_valid:
             raise InvalidEntityError("The requested MLCube is marked as INVALID.")
-        cube.download()
+        cube.download_config_files()
         return cube
 
     @classmethod
@@ -247,9 +247,7 @@ class Cube(Entity, Uploadable, MedperfSchema, DeployableSchema):
             verify_hash(local_hash, img_hash)
             self.image_hash = local_hash
 
-    def download(self):
-        """Downloads the required elements for an mlcube to run locally."""
-
+    def download_config_files(self):
         try:
             self.download_mlcube()
         except InvalidEntityError as e:
@@ -260,6 +258,7 @@ class Cube(Entity, Uploadable, MedperfSchema, DeployableSchema):
         except InvalidEntityError as e:
             raise InvalidEntityError(f"MLCube {self.name} parameters file: {e}")
 
+    def download_run_files(self):
         try:
             self.download_additional()
         except InvalidEntityError as e:

--- a/cli/medperf/entities/cube.py
+++ b/cli/medperf/entities/cube.py
@@ -225,10 +225,11 @@ class Cube(Entity, Uploadable, MedperfSchema, DeployableSchema):
                 self._set_image_hash_from_registry()
 
                 image_folder = os.path.join(config.cubes_folder, config.image_path)
-                for file in os.listdir(image_folder):
-                    if file == self._converted_singularity_image_name:
-                        return
-                    remove_path(os.path.join(image_folder, file))
+                if os.path.exists(image_folder):
+                    for file in os.listdir(image_folder):
+                        if file == self._converted_singularity_image_name:
+                            return
+                        remove_path(os.path.join(image_folder, file))
 
                 self._get_image_from_registry()
             else:

--- a/cli/medperf/entities/cube.py
+++ b/cli/medperf/entities/cube.py
@@ -349,6 +349,10 @@ class Cube(Entity, Uploadable, MedperfSchema, DeployableSchema):
         else:
             raise InvalidArgumentError("Unsupported platform")
 
+        # set accelerator count to zero to avoid unexpected behaviours and
+        # force mlcube to only use --gpus to figure out GPU config
+        cmd += " -Pplatform.accelerator_count=0"
+
         logging.info(f"Running MLCube command: {cmd}")
         proc = pexpect.spawn(cmd, timeout=timeout)
         proc_out = combine_proc_sp_text(proc)

--- a/cli/medperf/entities/cube.py
+++ b/cli/medperf/entities/cube.py
@@ -249,7 +249,6 @@ class Cube(Entity, Uploadable, MedperfSchema, DeployableSchema):
         with pexpect.spawn(cmd, timeout=config.mlcube_inspect_timeout) as proc:
             proc_stdout = proc.read()
         logging.debug(proc_stdout)
-        print(proc_stdout)
         if proc.exitstatus != 0:
             raise ExecutionError("There was an error while inspecting the image hash")
         with open(tmp_out_yaml) as f:

--- a/cli/medperf/tests/commands/dataset/test_create.py
+++ b/cli/medperf/tests/commands/dataset/test_create.py
@@ -4,7 +4,7 @@ from medperf.exceptions import InvalidArgumentError
 import pytest
 from unittest.mock import call
 
-from medperf.tests.mocks import MockCube
+from medperf.tests.mocks import TestCube
 from medperf.tests.mocks.benchmark import TestBenchmark
 from medperf.tests.mocks.dataset import TestDataset
 from medperf.commands.dataset.create import DataPreparation
@@ -39,7 +39,8 @@ def preparation(mocker, comms, ui):
         DESCRIPTION,
         LOCATION,
     )
-    mocker.patch(PATCH_DATAPREP.format("Cube.get"), return_value=MockCube(True))
+    mocker.patch(PATCH_DATAPREP.format("Cube.get"), return_value=TestCube())
+    mocker.patch(PATCH_DATAPREP.format("Cube.download_run_files"))
     preparation.get_prep_cube()
     preparation.data_path = DATA_PATH
     preparation.labels_path = LABELS_PATH
@@ -75,9 +76,8 @@ class TestWithDefaultUID:
         self, mocker, cube_uid, comms, ui
     ):
         # Arrange
-        spy = mocker.patch(
-            PATCH_DATAPREP.format("Cube.get"), return_value=MockCube(True)
-        )
+        spy = mocker.patch(PATCH_DATAPREP.format("Cube.get"), return_value=TestCube())
+        down_spy = mocker.patch(PATCH_DATAPREP.format("Cube.download_run_files"))
 
         # Act
         preparation = DataPreparation(None, cube_uid, *[""] * 5)
@@ -85,6 +85,7 @@ class TestWithDefaultUID:
 
         # Assert
         spy.assert_called_once_with(cube_uid)
+        down_spy.assert_called_once()
 
     @pytest.mark.parametrize("cube_uid", [998, 68, 109])
     def test_get_prep_cube_gets_benchmark_cube_if_provided(
@@ -93,9 +94,8 @@ class TestWithDefaultUID:
         # Arrange
         benchmark = TestBenchmark(data_preparation_mlcube=cube_uid)
         mocker.patch(PATCH_DATAPREP.format("Benchmark.get"), return_value=benchmark)
-        spy = mocker.patch(
-            PATCH_DATAPREP.format("Cube.get"), return_value=MockCube(True)
-        )
+        spy = mocker.patch(PATCH_DATAPREP.format("Cube.get"), return_value=TestCube())
+        down_spy = mocker.patch(PATCH_DATAPREP.format("Cube.download_run_files"))
 
         # Act
         preparation = DataPreparation(cube_uid, None, *[""] * 5)
@@ -103,6 +103,7 @@ class TestWithDefaultUID:
 
         # Assert
         spy.assert_called_once_with(cube_uid)
+        down_spy.assert_called_once()
 
     def test_run_cube_tasks_runs_required_tasks(self, mocker, preparation):
         # Arrange

--- a/cli/medperf/tests/commands/mlcube/test_submit.py
+++ b/cli/medperf/tests/commands/mlcube/test_submit.py
@@ -10,7 +10,8 @@ PATCH_MLCUBE = "medperf.commands.mlcube.submit.{}"
 
 @pytest.fixture
 def cube(mocker):
-    mocker.patch(PATCH_MLCUBE.format("Cube.download"))
+    mocker.patch(PATCH_MLCUBE.format("Cube.download_config_files"))
+    mocker.patch(PATCH_MLCUBE.format("Cube.download_run_files"))
     mocker.patch(PATCH_MLCUBE.format("Cube.upload"))
     mocker.patch(PATCH_MLCUBE.format("Cube.write"))
     return TestCube()
@@ -90,10 +91,11 @@ def test_upload_uploads_using_entity(mocker, comms, ui, cube):
 
 def test_download_executes_expected_commands(mocker, comms, ui, cube):
     submission = SubmitCube(cube.todict())
-    down_spy = mocker.patch(PATCH_MLCUBE.format("Cube.download"))
-
+    config_down_spy = mocker.patch(PATCH_MLCUBE.format("Cube.download_config_files"))
+    run_down_spy = mocker.patch(PATCH_MLCUBE.format("Cube.download_run_files"))
     # Act
     submission.download()
 
     # Assert
-    down_spy.assert_called_once_with()
+    config_down_spy.assert_called_once_with()
+    run_down_spy.assert_called_once_with()

--- a/cli/medperf/tests/commands/result/test_create.py
+++ b/cli/medperf/tests/commands/result/test_create.py
@@ -74,6 +74,7 @@ def mock_cube(mocker, state_variables):
         return cube
 
     mocker.patch(PATCH_EXECUTION.format("Cube.get"), side_effect=__get_side_effect)
+    mocker.patch(PATCH_EXECUTION.format("Cube.download_run_files"))
 
 
 def mock_execution(mocker, state_variables):

--- a/cli/medperf/tests/entities/test_cube.py
+++ b/cli/medperf/tests/entities/test_cube.py
@@ -60,12 +60,8 @@ class TestGetFiles:
             self.cube_path, config.additional_path, config.tarball_filename
         )
         self.img_path = os.path.join(self.cube_path, config.image_path, "img.tar.gz")
-        self.file_paths = [
-            self.manifest_path,
-            self.params_path,
-            self.add_path,
-            self.img_path,
-        ]
+        self.config_files_paths = [self.manifest_path, self.params_path]
+        self.run_files_paths = [self.add_path, self.img_path]
 
     @pytest.mark.parametrize("setup", [{"remote": [DEFAULT_CUBE]}], indirect=True)
     def test_get_cube_retrieves_files(self, setup):
@@ -73,11 +69,25 @@ class TestGetFiles:
         Cube.get(self.id)
 
         # Assert
-        for file in self.file_paths:
+        for file in self.config_files_paths:
+            assert os.path.exists(file) and os.path.isfile(file)
+        for file in self.run_files_paths:
+            assert not os.path.exists(file)
+
+    @pytest.mark.parametrize("setup", [{"remote": [DEFAULT_CUBE]}], indirect=True)
+    def test_download_run_files_retrieves_files(self, setup):
+        # Act
+        cube = Cube.get(self.id)
+        cube.download_run_files()
+
+        # Assert
+        for file in self.config_files_paths + self.run_files_paths:
             assert os.path.exists(file) and os.path.isfile(file)
 
     @pytest.mark.parametrize("setup", [{"remote": [NO_IMG_CUBE]}], indirect=True)
-    def test_get_cube_without_image_configures_mlcube(self, mocker, setup, fs):
+    def test_download_run_files_without_image_configures_mlcube(
+        self, mocker, setup, fs
+    ):
         # Arrange
         tmp_path = "tmp_path"
         mocker.patch(PATCH_CUBE.format("generate_tmp_path"), return_value=tmp_path)
@@ -87,20 +97,23 @@ class TestGetFiles:
         )
         spy = mocker.spy(medperf.entities.cube.pexpect, "spawn")
         expected_cmds = [
-            f"mlcube configure --mlcube={self.manifest_path}",
+            f"mlcube configure --mlcube={self.manifest_path} --platform={config.platform}",
             f"mlcube inspect --mlcube={self.manifest_path}"
-            f" --format=yaml --output-file {tmp_path}",
+            f" --format=yaml --platform={config.platform} --output-file {tmp_path}",
         ]
         expected_cmds = [call(cmd, timeout=None) for cmd in expected_cmds]
 
         # Act
-        Cube.get(self.id)
+        cube = Cube.get(self.id)
+        cube.download_run_files()
 
         # Assert
         spy.assert_has_calls(expected_cmds)
 
     @pytest.mark.parametrize("setup", [{"remote": [NO_IMG_CUBE]}], indirect=True)
-    def test_get_cube_stops_execution_if_configure_fails(self, mocker, setup, fs):
+    def test_download_run_files_stops_execution_if_configure_fails(
+        self, mocker, setup, fs
+    ):
         # Arrange
         tmp_path = "tmp_path"
         mocker.patch(PATCH_CUBE.format("generate_tmp_path"), return_value=tmp_path)
@@ -112,11 +125,14 @@ class TestGetFiles:
         mocker.patch("pexpect.spawn", side_effect=mpexpect.spawn)
 
         # Act & Assert
+        cube = Cube.get(self.id)
         with pytest.raises(ExecutionError):
-            Cube.get(self.id)
+            cube.download_run_files()
 
     @pytest.mark.parametrize("setup", [{"remote": [NO_IMG_CUBE]}], indirect=True)
-    def test_get_cube_without_image_fails_with_wrong_hash(self, mocker, setup, fs):
+    def test_download_run_files_without_image_fails_with_wrong_hash(
+        self, mocker, setup, fs
+    ):
         # Arrange
         tmp_path = "tmp_path"
         mocker.patch(PATCH_CUBE.format("generate_tmp_path"), return_value=tmp_path)
@@ -124,16 +140,18 @@ class TestGetFiles:
         fs.create_file("tmp_path", contents=yaml.dump({"hash": "invalid hash"}))
 
         # Act & Assert
+        cube = Cube.get(self.id)
         with pytest.raises(InvalidEntityError):
-            Cube.get(self.id)
+            cube.download_run_files()
 
     @pytest.mark.parametrize("setup", [{"remote": [DEFAULT_CUBE]}], indirect=True)
-    def test_get_cube_with_image_isnt_configured(self, mocker, setup):
+    def test_download_run_files_with_image_isnt_configured(self, mocker, setup):
         # Arrange
         spy = mocker.spy(medperf.entities.cube.pexpect, "spawn")
 
         # Act
-        Cube.get(self.id)
+        cube = Cube.get(self.id)
+        cube.download_run_files()
 
         # Assert
         spy.assert_not_called()
@@ -165,6 +183,7 @@ class TestRun:
             + f"--platform={self.platform} --network=none --mount=ro"
             + ' -Pdocker.cpu_args="-u $(id -u):$(id -g)"'
             + ' -Pdocker.gpu_args="-u $(id -u):$(id -g)"'
+            + " -Pplatform.accelerator_count=0"
         )
 
         # Act
@@ -187,6 +206,7 @@ class TestRun:
             + f"--platform={self.platform} --network=none"
             + ' -Pdocker.cpu_args="-u $(id -u):$(id -g)"'
             + ' -Pdocker.gpu_args="-u $(id -u):$(id -g)"'
+            + " -Pplatform.accelerator_count=0"
         )
 
         # Act
@@ -206,6 +226,7 @@ class TestRun:
             + f'--platform={self.platform} --network=none --mount=ro test="test"'
             + ' -Pdocker.cpu_args="-u $(id -u):$(id -g)"'
             + ' -Pdocker.gpu_args="-u $(id -u):$(id -g)"'
+            + " -Pplatform.accelerator_count=0"
         )
 
         # Act
@@ -228,6 +249,7 @@ class TestRun:
             + f"--platform={self.platform} --network=none --mount=ro"
             + ' -Pdocker.cpu_args="cpuarg cpuval -u $(id -u):$(id -g)"'
             + ' -Pdocker.gpu_args="gpuarg gpuval -u $(id -u):$(id -g)"'
+            + " -Pplatform.accelerator_count=0"
         )
 
         # Act

--- a/cli/medperf/tests/mocks/__init__.py
+++ b/cli/medperf/tests/mocks/__init__.py
@@ -1,6 +1,6 @@
 from .requests import MockResponse
 from .benchmark import Benchmark
-from .cube import MockCube
+from .cube import TestCube
 from .tarfile import MockTar
 
-all = [MockResponse, Benchmark, MockCube, MockTar]
+all = [MockResponse, Benchmark, TestCube, MockTar]

--- a/cli/medperf/tests/mocks/cube.py
+++ b/cli/medperf/tests/mocks/cube.py
@@ -5,26 +5,6 @@ from medperf.entities.cube import Cube
 EMPTY_FILE_HASH = "da39a3ee5e6b4b0d3255bfef95601890afd80709"
 
 
-class MockCube:
-    def __init__(self, is_valid):
-        self.name = "Test"
-        self.is_valid = is_valid
-        self.id = 1
-
-    def valid(self):
-        return self.is_valid
-
-    def run(self):
-        pass
-
-    def get_default_output(self, *args, **kwargs):
-        return "out_path"
-
-    @property
-    def identifier(self):
-        return self.id or self.name
-
-
 class TestCube(Cube):
     id: Optional[int] = 1
     name: str = "name"

--- a/cli/requirements.txt
+++ b/cli/requirements.txt
@@ -10,9 +10,9 @@ colorama==0.4.4
 time-machine==2.4.0
 pytest-mock==1.13.0
 pyfakefs==5.0.0
-mlcube @ git+https://github.com/mlcommons/mlcube@755d388edc9fb32dfa2b09c244252485b2b554b3#subdirectory=mlcube
-mlcube-docker @ git+https://github.com/mlcommons/mlcube@755d388edc9fb32dfa2b09c244252485b2b554b3#subdirectory=runners/mlcube_docker
-mlcube-singularity @ git+https://github.com/mlcommons/mlcube@755d388edc9fb32dfa2b09c244252485b2b554b3#subdirectory=runners/mlcube_singularity
+mlcube @ git+https://github.com/hasan7n/mlcube@404140c3b6d3e903da6828b741c3168b407737dc#subdirectory=mlcube
+mlcube-docker @ git+https://github.com/hasan7n/mlcube@404140c3b6d3e903da6828b741c3168b407737dc#subdirectory=runners/mlcube_docker
+mlcube-singularity @ git+https://github.com/hasan7n/mlcube@404140c3b6d3e903da6828b741c3168b407737dc#subdirectory=runners/mlcube_singularity
 validators==0.18.2
 merge-args==0.1.4
 synapseclient==2.7.0

--- a/cli/tests_setup.sh
+++ b/cli/tests_setup.sh
@@ -62,7 +62,7 @@ fi
 ##########################################################
 ########################## Setup #########################
 ##########################################################
-ASSETS_URL="https://raw.githubusercontent.com/hasan7n/mockcube/f1e59d5439c315782d0770240f48a1e03381eea1"
+ASSETS_URL="https://raw.githubusercontent.com/hasan7n/mockcube/32294ec0babbcb7773e40075e605ed6f18f6b125"
 
 # datasets
 DSET_A_URL="$ASSETS_URL/assets/datasets/dataset_a.tar.gz"

--- a/cli/tests_setup.sh
+++ b/cli/tests_setup.sh
@@ -62,7 +62,7 @@ fi
 ##########################################################
 ########################## Setup #########################
 ##########################################################
-ASSETS_URL="https://raw.githubusercontent.com/hasan7n/mockcube/036aaa0c156e1ce9b7952f3b4d5275caec30a0a9"
+ASSETS_URL="https://raw.githubusercontent.com/hasan7n/mockcube/f1e59d5439c315782d0770240f48a1e03381eea1"
 
 # datasets
 DSET_A_URL="$ASSETS_URL/assets/datasets/dataset_a.tar.gz"

--- a/cli/tests_setup.sh
+++ b/cli/tests_setup.sh
@@ -16,7 +16,6 @@ CLEANUP="${CLEANUP:-false}"
 FRESH="${FRESH:-false}"
 MEDPERF_STORAGE=~/.medperf
 SERVER_STORAGE_ID="$(echo $SERVER_URL | cut -d '/' -f 3 | sed -e 's/[.:]/_/g')"
-MEDPERF_LOG_STORAGE="$MEDPERF_STORAGE/logs/medperf.log"
 TIMEOUT="${TIMEOUT:-30}"
 VERSION_PREFIX="/api/v0"
 LOGIN_SCRIPT="$(dirname $(realpath "$0"))/auto_login.sh"
@@ -47,7 +46,7 @@ checkFailed(){
     fi
     echo $1
     echo "medperf log:"
-    tail "$MEDPERF_LOG_STORAGE"
+    tail "$MEDPERF_STORAGE/logs/medperf.log"
     if ${CLEANUP}; then
       clean
     fi

--- a/docs/getting_started/installation.md
+++ b/docs/getting_started/installation.md
@@ -22,10 +22,7 @@ We will assume the commands' names are `pip` and `python`. Use `pip3` and `pytho
 
 #### Docker or Singularity
 
-!!! warning
-    Singularity is temporarily not supported.
-
-Make sure you have the latest version of [Docker](https://docs.docker.com/get-docker/){target="\_blank"} or [Singularity 3.10](https://docs.sylabs.io/guides/3.0/user-guide/installation.html){target="\_blank"} installed.
+Make sure you have the latest version of [Docker](https://docs.docker.com/get-docker/){target="\_blank"} or [Singularity 3.10](https://docs.sylabs.io/guides/3.10/admin-guide/installation.html){target="\_blank"} installed.
 
 To verify docker is installed, run:
 

--- a/docs/getting_started/setup.md
+++ b/docs/getting_started/setup.md
@@ -56,9 +56,6 @@ medperf profile view
 
 #### Choose the Container Runner
 
-!!! warning
-    Singularity is temporarily not supported.
-
 You can configure the MedPerf client to use either Docker or Singularity. The `local` profile is configured to use Docker. If you want to use MedPerf with Singularity, modify the `local` profile configured parameters by running the following:
 
 ```bash


### PR DESCRIPTION
This PR:
- Singularity 3.10 is now supported
- clarify how GPUs are used 
- configuring the mlcube (e.g. pull docker image or converting it to singularity) now happens only when needed, not whenever the mlcube is retrieved

