### PR TITLE
thread-safe token refresh

### DIFF
--- a/cli/medperf/account_management/token_storage/filesystem.py
+++ b/cli/medperf/account_management/token_storage/filesystem.py
@@ -1,5 +1,6 @@
 import os
 import base64
+import logging
 from medperf.utils import remove_path
 from medperf import config
 
@@ -27,7 +28,7 @@ class FilesystemTokenStore:
 
     def set_tokens(self, account_id, access_token, refresh_token):
         access_token_file, refresh_token_file = self.__get_paths(account_id)
-
+        logging.debug("Writing tokens to disk.")
         fd = os.open(access_token_file, os.O_CREAT | os.O_WRONLY, 0o600)
         os.write(fd, access_token.encode("utf-8"))
         os.close(fd)
@@ -38,6 +39,7 @@ class FilesystemTokenStore:
 
     def read_tokens(self, account_id):
         access_token_file, refresh_token_file = self.__get_paths(account_id)
+        logging.debug("Reading tokens to disk.")
         with open(access_token_file) as f:
             access_token = f.read()
         with open(refresh_token_file) as f:

--- a/cli/medperf/comms/auth/auth0.py
+++ b/cli/medperf/comms/auth/auth0.py
@@ -1,4 +1,5 @@
 import time
+import logging
 import threading
 from medperf.comms.auth.interface import Auth
 from medperf.comms.auth.token_verifier import verify_token
@@ -201,6 +202,7 @@ class Auth0(Auth):
             "refresh_token": refresh_token,
         }
         token_issued_at = time.time()
+        logging.debug("Refreshing access token.")
         res = requests.post(url=url, headers=headers, data=body)
 
         if res.status_code != 200:

--- a/cli/medperf/comms/auth/auth0.py
+++ b/cli/medperf/comms/auth/auth0.py
@@ -220,8 +220,8 @@ class Auth0(Auth):
             access_token,
             refresh_token,
             id_token_payload,
-            token_expires_in,
             token_issued_at,
+            token_expires_in,
         )
 
         return access_token

--- a/cli/medperf/tests/comms/test_auth0.py
+++ b/cli/medperf/tests/comms/test_auth0.py
@@ -87,5 +87,5 @@ def test_refresh_token_sets_new_tokens(mocker):
 
     # Assert
     spy.assert_called_once_with(
-        access_token, refresh_token, id_token_payload, expires_in, ANY
+        access_token, refresh_token, id_token_payload, ANY, expires_in
     )


### PR DESCRIPTION
wraps the authentication class's `access_token` method under a threading lock to make it thread-safe and prevents the possibility of having multiple threads trying to refresh the access token, which may result in refresh token reuse since we use refresh token rotation