### PR TITLE
Fix token storage bug

### DIFF
--- a/cli/medperf/account_management/account_management.py
+++ b/cli/medperf/account_management/account_management.py
@@ -7,7 +7,7 @@ from medperf.exceptions import MedperfException
 def read_user_account():
     config_p = read_config()
     if config.credentials_keyword not in config_p.active_profile:
-        raise MedperfException("You are not logged in")
+        return
 
     account_info = config_p.active_profile[config.credentials_keyword]
     return account_info
@@ -35,6 +35,8 @@ def set_credentials(
 
 def read_credentials():
     account_info = read_user_account()
+    if account_info is None:
+        raise MedperfException("You are not logged in")
     email = account_info["email"]
     access_token, refresh_token = TokenStore().read_tokens(email)
 

--- a/cli/medperf/account_management/token_storage/filesystem.py
+++ b/cli/medperf/account_management/token_storage/filesystem.py
@@ -28,13 +28,17 @@ class FilesystemTokenStore:
     def set_tokens(self, account_id, access_token, refresh_token):
         access_token_file, refresh_token_file = self.__get_paths(account_id)
 
-        fd = os.open(access_token_file, os.O_CREAT | os.O_WRONLY, 0o600)
-        os.write(fd, access_token.encode("utf-8"))
-        os.close(fd)
+        with open(access_token_file, "w") as f:
+            pass
+        os.chmod(access_token_file, 0o600)
+        with open(access_token_file, "a") as f:
+            f.write(access_token)
 
-        fd = os.open(refresh_token_file, os.O_CREAT | os.O_WRONLY, 0o600)
-        os.write(fd, refresh_token.encode("utf-8"))
-        os.close(fd)
+        with open(refresh_token_file, "w") as f:
+            pass
+        os.chmod(refresh_token_file, 0o600)
+        with open(refresh_token_file, "a") as f:
+            f.write(refresh_token)
 
     def read_tokens(self, account_id):
         access_token_file, refresh_token_file = self.__get_paths(account_id)

--- a/cli/medperf/commands/auth/login.py
+++ b/cli/medperf/commands/auth/login.py
@@ -1,6 +1,16 @@
 import medperf.config as config
-from medperf.exceptions import InvalidArgumentError
+from medperf.account_management import read_user_account
+from medperf.exceptions import InvalidArgumentError, MedperfException
 from email_validator import validate_email, EmailNotValidError
+
+
+def raise_if_logged_in():
+    account_info = read_user_account()
+    if account_info is not None:
+        raise MedperfException(
+            f"You are already logged in as {account_info['email']}."
+            " Logout before logging in again"
+        )
 
 
 class Login:
@@ -8,6 +18,7 @@ class Login:
     def run(email: str = None):
         """Authenticate to be able to access the MedPerf server. A verification link will
         be provided and should be open in a browser to complete the login process."""
+        raise_if_logged_in()
         if not email:
             email = config.ui.prompt("Please type your email: ")
         try:

--- a/cli/medperf/commands/auth/status.py
+++ b/cli/medperf/commands/auth/status.py
@@ -1,17 +1,14 @@
 import medperf.config as config
 from medperf.account_management import read_user_account
-from medperf.exceptions import MedperfException
 
 
 class Status:
     @staticmethod
     def run():
         """Shows the currently logged in user."""
-        try:
-            account_info = read_user_account()
-        except MedperfException as e:
-            # TODO: create a specific exception about unauthenticated client
-            config.ui.print(str(e))
+        account_info = read_user_account()
+        if account_info is None:
+            config.ui.print("You are not logged in")
             return
 
         email = account_info["email"]


### PR DESCRIPTION
- Drops the usage of `os.open` and uses the built-in `open` for storing the tokens. It creates an empty file first, changes its permissions, then appends the token.

This PR also Forces logout for authenticated users who try to login again (to prevent refresh token count build up; to not lose track of active refresh tokens without revoking them). This is not related to the storage bug, but it is better to be implemented.