### PR TITLE
Mlcube download log

### DIFF
--- a/cli/medperf/entities/cube.py
+++ b/cli/medperf/entities/cube.py
@@ -249,7 +249,7 @@ class Cube(Entity, Uploadable, MedperfSchema, DeployableSchema):
         cmd += f" --platform={config.platform} --output-file {tmp_out_yaml}"
         logging.info(f"Running MLCube command: {cmd}")
         with pexpect.spawn(cmd, timeout=config.mlcube_inspect_timeout) as proc:
-            proc_stdout = proc.read()
+            proc_stdout = combine_proc_sp_text(proc)
         logging.debug(proc_stdout)
         if proc.exitstatus != 0:
             raise ExecutionError("There was an error while inspecting the image hash")
@@ -268,7 +268,7 @@ class Cube(Entity, Uploadable, MedperfSchema, DeployableSchema):
             cmd += f" -Psingularity.image={self._converted_singularity_image_name}"
         logging.info(f"Running MLCube command: {cmd}")
         with pexpect.spawn(cmd, timeout=config.mlcube_configure_timeout) as proc:
-            proc_out = proc.read()
+            proc_out = combine_proc_sp_text(proc)
         if proc.exitstatus != 0:
             raise ExecutionError("There was an error while retrieving the MLCube image")
         logging.debug(proc_out)

--- a/cli/medperf/entities/cube.py
+++ b/cli/medperf/entities/cube.py
@@ -249,8 +249,7 @@ class Cube(Entity, Uploadable, MedperfSchema, DeployableSchema):
         cmd += f" --platform={config.platform} --output-file {tmp_out_yaml}"
         logging.info(f"Running MLCube command: {cmd}")
         with pexpect.spawn(cmd, timeout=config.mlcube_inspect_timeout) as proc:
-            proc_stdout = combine_proc_sp_text(proc)
-        logging.debug(proc_stdout)
+            combine_proc_sp_text(proc)
         if proc.exitstatus != 0:
             raise ExecutionError("There was an error while inspecting the image hash")
         with open(tmp_out_yaml) as f:
@@ -268,10 +267,9 @@ class Cube(Entity, Uploadable, MedperfSchema, DeployableSchema):
             cmd += f" -Psingularity.image={self._converted_singularity_image_name}"
         logging.info(f"Running MLCube command: {cmd}")
         with pexpect.spawn(cmd, timeout=config.mlcube_configure_timeout) as proc:
-            proc_out = combine_proc_sp_text(proc)
+            combine_proc_sp_text(proc)
         if proc.exitstatus != 0:
             raise ExecutionError("There was an error while retrieving the MLCube image")
-        logging.debug(proc_out)
 
     def download_config_files(self):
         try:
@@ -366,9 +364,7 @@ class Cube(Entity, Uploadable, MedperfSchema, DeployableSchema):
         with pexpect.spawn(cmd, timeout=timeout) as proc:
             proc_out = combine_proc_sp_text(proc)
 
-        if output_logs is None:
-            logging.debug(proc_out)
-        else:
+        if output_logs is not None:
             with open(output_logs, "w") as f:
                 f.write(proc_out)
         if proc.exitstatus != 0:

--- a/cli/medperf/tests/ui/test_cli.py
+++ b/cli/medperf/tests/ui/test_cli.py
@@ -21,7 +21,18 @@ class TestDisplayingMessages:
         cli.print(msg)
 
         # Assert
-        spy.assert_called_once_with(msg)
+        spy.assert_called_once_with(msg, nl=True)
+
+    @pytest.mark.parametrize("nl", [True, False])
+    def test_print_typer_new_line(self, mocker, cli, msg, nl):
+        # Arrange
+        spy = mocker.patch("typer.echo")
+
+        # Act
+        cli.print(msg, nl=nl)
+
+        # Assert
+        spy.assert_called_once_with(msg, nl=nl)
 
     def test_print_displays_message_through_yaspin_when_interactive(
         self, mocker, cli, msg

--- a/cli/medperf/ui/cli.py
+++ b/cli/medperf/ui/cli.py
@@ -11,13 +11,14 @@ class CLI(UI):
         self.spinner = yaspin(color="green")
         self.is_interactive = False
 
-    def print(self, msg: str = ""):
+    def print(self, msg: str = "", nl: bool = True):
         """Display a message on the command line
 
         Args:
             msg (str): message to print
+            nl: if print a new line after message
         """
-        self.__print(msg)
+        self.__print(msg, nl=nl)
 
     def print_error(self, msg: str):
         """Display an error message on the command line
@@ -38,11 +39,14 @@ class CLI(UI):
         msg = typer.style(msg, fg=typer.colors.YELLOW, bold=True)
         self.__print(msg)
 
-    def __print(self, msg: str = ""):
+    def __print(self, msg: str = "", nl: bool = True):
         if self.is_interactive:
+            # TODO: nl does not work for yaspin as new-line character
+            #  is explicitly hardcoded in spinner.write()
             self.spinner.write(msg)
         else:
-            typer.echo(msg)
+            # pass
+            typer.echo(msg, nl=nl)
 
     def start_interactive(self):
         """Start an interactive session where messages can be overwritten

--- a/cli/medperf/ui/interface.py
+++ b/cli/medperf/ui/interface.py
@@ -1,4 +1,4 @@
-from abc import ABC, abstractmethod, abstractproperty
+from abc import ABC, abstractmethod
 from contextlib import contextmanager
 
 

--- a/cli/medperf/ui/interface.py
+++ b/cli/medperf/ui/interface.py
@@ -1,10 +1,12 @@
-from abc import ABC, abstractmethod
+from abc import ABC, abstractmethod, abstractproperty
 from contextlib import contextmanager
 
 
 class UI(ABC):
+    is_interactive: bool = False
+
     @abstractmethod
-    def print(self, msg: str = ""):
+    def print(self, msg: str = "", nl: bool = True):
         """Display a message to the interface. If on interactive session overrides
         previous message
         """
@@ -33,19 +35,17 @@ class UI(ABC):
     def interactive(self):
         """Context managed interactive session. Expected to yield the same instance"""
 
+    @property
     @abstractmethod
-    def text(self, msg: str):
+    def text(self):
         """Displays a messages that overwrites previous messages if they were created
         during an interactive session.
         If not supported or not on an interactive session, it is expected to fallback
         to the UI print function.
-
-        Args:
-            msg (str): message to display
         """
 
     @abstractmethod
-    def prompt(msg: str) -> str:
+    def prompt(self, msg: str) -> str:
         """Displays a prompt to the user and waits for an answer"""
 
     @abstractmethod

--- a/cli/medperf/ui/stdin.py
+++ b/cli/medperf/ui/stdin.py
@@ -11,8 +11,8 @@ class StdIn(UI):
     hidden prompts and interactive prints will not work as expected.
     """
 
-    def print(self, msg: str = ""):
-        return print(msg)
+    def print(self, msg: str = "", nl: bool = True):
+        return print(msg, end='\n' if nl else '')
 
     def print_error(self, msg: str):
         return self.print(msg)
@@ -40,3 +40,6 @@ class StdIn(UI):
 
     def hidden_prompt(self, msg: str) -> str:
         return self.prompt(msg)
+
+    def print_highlight(self, msg: str = ""):
+        self.print(msg)

--- a/cli/medperf/utils.py
+++ b/cli/medperf/utils.py
@@ -266,17 +266,22 @@ def combine_proc_sp_text(proc: spawn) -> str:
             line = proc.readline()
         except TIMEOUT:
             logging.error("Process timed out")
+            logging.debug(proc_out)
             raise ExecutionError("Process timed out")
         line = line.decode("utf-8", "ignore")
 
         if not line:
             continue
 
-        if log_filter.check_line(line):
-            logging.debug(line)
-        else:
-            proc_out += line
+        # Always log each line just in case the final proc_out
+        # wasn't logged for some reason
+        logging.debug(line)
+        proc_out += line
+        if not log_filter.check_line(line):
             ui.print(f"{Fore.WHITE}{Style.DIM}{line.strip()}{Style.RESET_ALL}")
+
+    logging.debug("MLCube process finished")
+    logging.debug(proc_out)
     return proc_out
 
 

--- a/cli/medperf/utils.py
+++ b/cli/medperf/utils.py
@@ -255,7 +255,6 @@ def combine_proc_sp_text(proc: spawn) -> str:
     """
 
     ui = config.ui
-    static_text = ui.text
     proc_out = ""
     break_ = False
     log_filter = _MLCubeOutputFilter(proc.pid)
@@ -278,7 +277,6 @@ def combine_proc_sp_text(proc: spawn) -> str:
         else:
             proc_out += line
             ui.print(f"{Fore.WHITE}{Style.DIM}{line.strip()}{Style.RESET_ALL}")
-            ui.text = static_text
     return proc_out
 
 


### PR DESCRIPTION
Replacement of https://github.com/hasan7n/medperf/pull/3 as that base branch was already merged into main

While reading output from spawned mlcube process, stop&display not only when a full line (ending with \n) is found, but when a line update (ending with \r) is got.