### PR TITLE
Mlcube download docker cli hints

### DIFF
--- a/cli/medperf/entities/cube.py
+++ b/cli/medperf/entities/cube.py
@@ -249,7 +249,7 @@ class Cube(Entity, Uploadable, MedperfSchema, DeployableSchema):
         cmd += f" --platform={config.platform} --output-file {tmp_out_yaml}"
         logging.info(f"Running MLCube command: {cmd}")
         with pexpect.spawn(cmd, timeout=config.mlcube_inspect_timeout) as proc:
-            proc_stdout = proc.read()
+            proc_stdout = combine_proc_sp_text(proc)
         logging.debug(proc_stdout)
         if proc.exitstatus != 0:
             raise ExecutionError("There was an error while inspecting the image hash")
@@ -268,7 +268,7 @@ class Cube(Entity, Uploadable, MedperfSchema, DeployableSchema):
             cmd += f" -Psingularity.image={self._converted_singularity_image_name}"
         logging.info(f"Running MLCube command: {cmd}")
         with pexpect.spawn(cmd, timeout=config.mlcube_configure_timeout) as proc:
-            proc_out = proc.read()
+            proc_out = combine_proc_sp_text(proc)
         if proc.exitstatus != 0:
             raise ExecutionError("There was an error while retrieving the MLCube image")
         logging.debug(proc_out)

--- a/cli/medperf/entities/cube.py
+++ b/cli/medperf/entities/cube.py
@@ -249,8 +249,7 @@ class Cube(Entity, Uploadable, MedperfSchema, DeployableSchema):
         cmd += f" --platform={config.platform} --output-file {tmp_out_yaml}"
         logging.info(f"Running MLCube command: {cmd}")
         with pexpect.spawn(cmd, timeout=config.mlcube_inspect_timeout) as proc:
-            proc_stdout = combine_proc_sp_text(proc)
-        logging.debug(proc_stdout)
+            combine_proc_sp_text(proc)
         if proc.exitstatus != 0:
             raise ExecutionError("There was an error while inspecting the image hash")
         with open(tmp_out_yaml) as f:
@@ -268,10 +267,9 @@ class Cube(Entity, Uploadable, MedperfSchema, DeployableSchema):
             cmd += f" -Psingularity.image={self._converted_singularity_image_name}"
         logging.info(f"Running MLCube command: {cmd}")
         with pexpect.spawn(cmd, timeout=config.mlcube_configure_timeout) as proc:
-            proc_out = combine_proc_sp_text(proc)
+            combine_proc_sp_text(proc)
         if proc.exitstatus != 0:
             raise ExecutionError("There was an error while retrieving the MLCube image")
-        logging.debug(proc_out)
 
     def download_config_files(self):
         try:
@@ -366,9 +364,7 @@ class Cube(Entity, Uploadable, MedperfSchema, DeployableSchema):
         with pexpect.spawn(cmd, timeout=timeout) as proc:
             proc_out = combine_proc_sp_text(proc)
 
-        if output_logs is None:
-            logging.debug(proc_out)
-        else:
+        if output_logs is not None:
             with open(output_logs, "w") as f:
                 f.write(proc_out)
         if proc.exitstatus != 0:

--- a/cli/medperf/tests/entities/test_cube.py
+++ b/cli/medperf/tests/entities/test_cube.py
@@ -44,6 +44,15 @@ def setup(request, mocker, comms, fs):
 
     return request.param
 
+def remove_env_from_mock_calls(spy) -> None:
+    """
+    During cube downloading, we pass `env` variable that contains all ENVs from medperf process.
+    As this is dynamic variable, we don't bother about what is passed there; so we do not want to test it.
+    Thus, we just remove passed `env` from executed calls, for it not to intersect assertion
+    """
+    for executed_call in spy.mock_calls:
+        if 'env' in executed_call.kwargs:
+            executed_call.kwargs.pop('env')
 
 class TestGetFiles:
     @pytest.fixture(autouse=True)
@@ -107,6 +116,7 @@ class TestGetFiles:
         cube = Cube.get(self.id)
         cube.download_run_files()
 
+        remove_env_from_mock_calls(spy)
         # Assert
         spy.assert_has_calls(expected_cmds)
 
@@ -190,6 +200,7 @@ class TestRun:
         cube = Cube.get(self.id)
         cube.run(task, timeout=timeout)
 
+        remove_env_from_mock_calls(spy)
         # Assert
         spy.assert_any_call(expected_cmd, timeout=timeout)
 
@@ -213,6 +224,7 @@ class TestRun:
         cube = Cube.get(self.id)
         cube.run(task, read_protected_input=False)
 
+        remove_env_from_mock_calls(spy)
         # Assert
         spy.assert_any_call(expected_cmd, timeout=None)
 
@@ -233,6 +245,7 @@ class TestRun:
         cube = Cube.get(self.id)
         cube.run(task, test="test")
 
+        remove_env_from_mock_calls(spy)
         # Assert
         spy.assert_any_call(expected_cmd, timeout=None)
 
@@ -256,6 +269,7 @@ class TestRun:
         cube = Cube.get(self.id)
         cube.run(task)
 
+        remove_env_from_mock_calls(spy)
         # Assert
         spy.assert_any_call(expected_cmd, timeout=None)
 

--- a/cli/medperf/tests/entities/test_cube.py
+++ b/cli/medperf/tests/entities/test_cube.py
@@ -45,6 +45,7 @@ def setup(request, mocker, comms, fs):
 
     return request.param
 
+
 def remove_env_from_mock_calls(spy) -> None:
     """
     During cube downloading, we pass `env` variable that contains all ENVs from medperf process.
@@ -54,6 +55,7 @@ def remove_env_from_mock_calls(spy) -> None:
     for executed_call in spy.mock_calls:
         if 'env' in executed_call.kwargs:
             executed_call.kwargs.pop('env')
+
 
 class TestGetFiles:
     @pytest.fixture(autouse=True)

--- a/cli/medperf/tests/mocks/pexpect.py
+++ b/cli/medperf/tests/mocks/pexpect.py
@@ -24,5 +24,5 @@ class MockPexpect:
         self.exitstatus = exitstatus
         self.stdout = stdout
 
-    def spawn(self, command: str, timeout: int = 30) -> MockChild:
+    def spawn(self, command: str, timeout: int = 30, env: dict = None) -> MockChild:
         return MockChild(self.exitstatus, self.stdout)

--- a/cli/medperf/utils.py
+++ b/cli/medperf/utils.py
@@ -266,17 +266,22 @@ def combine_proc_sp_text(proc: spawn) -> str:
             line = proc.readline()
         except TIMEOUT:
             logging.error("Process timed out")
+            logging.debug(proc_out)
             raise ExecutionError("Process timed out")
         line = line.decode("utf-8", "ignore")
 
         if not line:
             continue
 
-        if log_filter.check_line(line):
-            logging.debug(line)
-        else:
-            proc_out += line
+        # Always log each line just in case the final proc_out
+        # wasn't logged for some reason
+        logging.debug(line)
+        proc_out += line
+        if not log_filter.check_line(line):
             ui.print(f"{Fore.WHITE}{Style.DIM}{line.strip()}{Style.RESET_ALL}")
+
+    logging.debug("MLCube process finished")
+    logging.debug(proc_out)
     return proc_out
 
 

--- a/cli/medperf/utils.py
+++ b/cli/medperf/utils.py
@@ -255,7 +255,6 @@ def combine_proc_sp_text(proc: spawn) -> str:
     """
 
     ui = config.ui
-    static_text = ui.text
     proc_out = ""
     break_ = False
     log_filter = _MLCubeOutputFilter(proc.pid)
@@ -278,7 +277,6 @@ def combine_proc_sp_text(proc: spawn) -> str:
         else:
             proc_out += line
             ui.print(f"{Fore.WHITE}{Style.DIM}{line.strip()}{Style.RESET_ALL}")
-            ui.text = static_text
     return proc_out
 
 


### PR DESCRIPTION
Replacement of https://github.com/hasan7n/medperf/pull/4 as that base branch was already merged into main.

Hide hints from docker cli output when we do `docker pull`