### PR TITLE
[feat] Upgrade synapseclient version; update `synapse_login` command

### DIFF
--- a/cli/medperf/commands/auth/auth.py
+++ b/cli/medperf/commands/auth/auth.py
@@ -12,12 +12,6 @@ app = typer.Typer()
 @app.command("synapse_login")
 @clean_except
 def synapse_login(
-    username: str = typer.Option(
-        None, "--username", "-u", help="Username to login with"
-    ),
-    password: str = typer.Option(
-        None, "--password", "-p", help="Password to login with"
-    ),
     token: str = typer.Option(
         None, "--token", "-t", help="Personal Access Token to login with"
     ),
@@ -25,7 +19,7 @@ def synapse_login(
     """Login to the synapse server.
     Provide either a username and a password, or a token
     """
-    SynapseLogin.run(username=username, password=password, token=token)
+    SynapseLogin.run(token=token)
     config.ui.print("✅ Done!")
 
 

--- a/cli/medperf/commands/auth/synapse_login.py
+++ b/cli/medperf/commands/auth/synapse_login.py
@@ -30,17 +30,7 @@ class SynapseLogin:
             else:
                 cls.login_with_password(username, password)
 
-    @classmethod
-    def login_with_password(cls, username: str = None, password: str = None):
-        """Login to the Synapse server. Must be done only once."""
-        username = username if username else config.ui.prompt("username: ")
-        password = password if password else config.ui.hidden_prompt("password: ")
 
-        syn = synapseclient.Synapse()
-        try:
-            syn.login(username, password, rememberMe=True)
-        except SynapseAuthenticationError:
-            raise CommunicationAuthenticationError("Invalid Synapse credentials")
 
     @classmethod
     def login_with_token(cls, access_token=None):

--- a/cli/medperf/commands/auth/synapse_login.py
+++ b/cli/medperf/commands/auth/synapse_login.py
@@ -9,9 +9,12 @@ class SynapseLogin:
     def run(cls, token: str = None):
         """Login to the Synapse server. Must be done only once."""
         if not token:
-            msg = "Please provide your Synapse Personal Access Token (PAT). "
-            msg += "You can generate a new PAT at https://www.synapse.org/#!PersonalAccessTokens:0\n"
-            msg += "Synapse PAT: "
+            msg = (
+                "Please provide your Synapse Personal Access Token (PAT). "
+                "You can generate a new PAT at "
+                "https://www.synapse.org/#!PersonalAccessTokens:0\n"
+                "Synapse PAT: "
+            )
             token = config.ui.hidden_prompt(msg)
         cls.login_with_token(token)
 

--- a/cli/medperf/commands/auth/synapse_login.py
+++ b/cli/medperf/commands/auth/synapse_login.py
@@ -24,5 +24,5 @@ class SynapseLogin:
         syn = synapseclient.Synapse()
         try:
             syn.login(authToken=access_token)
-        except SynapseAuthenticationError:
-            raise CommunicationAuthenticationError("Invalid Synapse credentials")
+        except SynapseAuthenticationError as err:
+            raise CommunicationAuthenticationError("Invalid Synapse credentials") from err

--- a/cli/medperf/commands/auth/synapse_login.py
+++ b/cli/medperf/commands/auth/synapse_login.py
@@ -1,7 +1,7 @@
 from medperf import config
 import synapseclient
 from synapseclient.core.exceptions import SynapseAuthenticationError
-from medperf.exceptions import CommunicationAuthenticationError, InvalidArgumentError
+from medperf.exceptions import CommunicationAuthenticationError
 
 
 class SynapseLogin:

--- a/cli/medperf/commands/auth/synapse_login.py
+++ b/cli/medperf/commands/auth/synapse_login.py
@@ -1,6 +1,6 @@
-from medperf import config
 import synapseclient
 from synapseclient.core.exceptions import SynapseAuthenticationError
+from medperf import config
 from medperf.exceptions import CommunicationAuthenticationError
 
 

--- a/cli/medperf/commands/auth/synapse_login.py
+++ b/cli/medperf/commands/auth/synapse_login.py
@@ -6,30 +6,14 @@ from medperf.exceptions import CommunicationAuthenticationError, InvalidArgument
 
 class SynapseLogin:
     @classmethod
-    def run(cls, username: str = None, password: str = None, token: str = None):
+    def run(cls, token: str = None):
         """Login to the Synapse server. Must be done only once."""
-        if not any([username, password, token]):
-            msg = "How do you want to login?\n"
-            msg += "[1] Personal Access Token\n"
-            msg += "[2] Username and Password\n"
-            msg += "Select an option (1 or 2): "
-            method = config.ui.prompt(msg)
-            if method == "1":
-                cls.login_with_token()
-            elif method == "2":
-                cls.login_with_password()
-            else:
-                raise InvalidArgumentError("Invalid input. Select either number 1 or 2")
-        else:
-            if token:
-                if any([username, password]):
-                    raise InvalidArgumentError(
-                        "Invalid input. Either an access token, or a username and password, should be given"
-                    )
-                cls.login_with_token(token)
-            else:
-                cls.login_with_password(username, password)
-
+        if not token:
+            msg = "Please provide your Synapse Personal Access Token (PAT). "
+            msg += "You can generate a new PAT at https://www.synapse.org/#!PersonalAccessTokens:0\n"
+            msg += "Synapse PAT: "
+            token = config.ui.hidden_prompt(msg)
+        cls.login_with_token(token)
 
 
     @classmethod

--- a/cli/medperf/commands/auth/synapse_login.py
+++ b/cli/medperf/commands/auth/synapse_login.py
@@ -18,7 +18,6 @@ class SynapseLogin:
             token = config.ui.hidden_prompt(msg)
         cls.login_with_token(token)
 
-
     @classmethod
     def login_with_token(cls, access_token=None):
         """Login to the Synapse server. Must be done only once."""

--- a/cli/medperf/commands/auth/synapse_login.py
+++ b/cli/medperf/commands/auth/synapse_login.py
@@ -19,12 +19,8 @@ class SynapseLogin:
     @classmethod
     def login_with_token(cls, access_token=None):
         """Login to the Synapse server. Must be done only once."""
-        access_token = (
-            access_token if access_token else config.ui.hidden_prompt("access token: ")
-        )
-
         syn = synapseclient.Synapse()
         try:
-            syn.login(authToken=access_token, rememberMe=True)
+            syn.login(authToken=access_token)
         except SynapseAuthenticationError:
             raise CommunicationAuthenticationError("Invalid Synapse credentials")

--- a/cli/medperf/tests/commands/auth/test_synapse_login.py
+++ b/cli/medperf/tests/commands/auth/test_synapse_login.py
@@ -26,15 +26,6 @@ def test_run_fails_if_error(mocker, synapse_client, ui):
         SynapseLogin.run(token="token")
 
 
-def test_run_fails_if_invalid_args(mocker, synapse_client, ui):
-    # Act & Assert
-    with pytest.raises(InvalidArgumentError):
-        SynapseLogin.run("usr", "pwd", "token")
-
-    with pytest.raises(InvalidArgumentError):
-        SynapseLogin.run("usr", None, "token")
-
-
 @pytest.mark.parametrize("user_input", ["1", "2"])
 def test_run_calls_the_correct_method(mocker, synapse_client, ui, user_input):
     # Arrange
@@ -52,16 +43,6 @@ def test_run_calls_the_correct_method(mocker, synapse_client, ui, user_input):
         # i.e. the user chose password login
         token_spy.assert_not_called()
 
-
-def test_login_with_password_calls_synapse_login(mocker, synapse_client, ui):
-    # Arrange
-    spy = mocker.patch.object(synapse_client, "login")
-
-    # Act
-    SynapseLogin.login_with_password("usr", "pwd")
-
-    # Assert
-    spy.assert_called_once_with("usr", "pwd", rememberMe=True)
 
 
 def test_login_with_token_calls_synapse_login(mocker, synapse_client, ui):

--- a/cli/medperf/tests/commands/auth/test_synapse_login.py
+++ b/cli/medperf/tests/commands/auth/test_synapse_login.py
@@ -23,9 +23,6 @@ def test_run_fails_if_error(mocker, synapse_client, ui):
 
     # Act & Assert
     with pytest.raises(CommunicationAuthenticationError):
-        SynapseLogin.run("usr", "pwd")
-
-    with pytest.raises(CommunicationAuthenticationError):
         SynapseLogin.run(token="token")
 
 
@@ -43,7 +40,6 @@ def test_run_calls_the_correct_method(mocker, synapse_client, ui, user_input):
     # Arrange
     mocker.patch.object(ui, "prompt", return_value=user_input)
     token_spy = mocker.patch(PATCH_LOGIN.format("SynapseLogin.login_with_token"))
-    pwd_spy = mocker.patch(PATCH_LOGIN.format("SynapseLogin.login_with_password"))
 
     # Act
     SynapseLogin.run()
@@ -52,11 +48,9 @@ def test_run_calls_the_correct_method(mocker, synapse_client, ui, user_input):
     if user_input == "1":
         # i.e. the user chose token login
         token_spy.assert_called_once()
-        pwd_spy.assert_not_called()
     else:
         # i.e. the user chose password login
         token_spy.assert_not_called()
-        pwd_spy.assert_called_once()
 
 
 def test_login_with_password_calls_synapse_login(mocker, synapse_client, ui):

--- a/cli/medperf/tests/commands/auth/test_synapse_login.py
+++ b/cli/medperf/tests/commands/auth/test_synapse_login.py
@@ -2,7 +2,7 @@ import pytest
 from medperf.commands.auth.synapse_login import SynapseLogin
 import synapseclient
 from synapseclient.core.exceptions import SynapseAuthenticationError
-from medperf.exceptions import CommunicationAuthenticationError, InvalidArgumentError
+from medperf.exceptions import CommunicationAuthenticationError
 
 PATCH_LOGIN = "medperf.commands.auth.synapse_login.{}"
 

--- a/cli/medperf/tests/commands/auth/test_synapse_login.py
+++ b/cli/medperf/tests/commands/auth/test_synapse_login.py
@@ -26,23 +26,16 @@ def test_run_fails_if_error(mocker, synapse_client, ui):
         SynapseLogin.run(token="token")
 
 
-@pytest.mark.parametrize("user_input", ["1", "2"])
-def test_run_calls_the_correct_method(mocker, synapse_client, ui, user_input):
+def test_run_calls_the_correct_method(mocker, synapse_client, ui):
     # Arrange
-    mocker.patch.object(ui, "prompt", return_value=user_input)
+    mocker.patch.object(ui, "prompt")
     token_spy = mocker.patch(PATCH_LOGIN.format("SynapseLogin.login_with_token"))
 
     # Act
     SynapseLogin.run()
 
     # Assert
-    if user_input == "1":
-        # i.e. the user chose token login
-        token_spy.assert_called_once()
-    else:
-        # i.e. the user chose password login
-        token_spy.assert_not_called()
-
+    token_spy.assert_called_once()
 
 
 def test_login_with_token_calls_synapse_login(mocker, synapse_client, ui):
@@ -53,4 +46,4 @@ def test_login_with_token_calls_synapse_login(mocker, synapse_client, ui):
     SynapseLogin.login_with_token("token")
 
     # Assert
-    spy.assert_called_once_with(authToken="token", rememberMe=True)
+    spy.assert_called_once_with(authToken="token")

--- a/cli/requirements.txt
+++ b/cli/requirements.txt
@@ -15,7 +15,7 @@ mlcube-docker @ git+https://github.com/hasan7n/mlcube@d35df3e3638dfd051c8600096e
 mlcube-singularity @ git+https://github.com/hasan7n/mlcube@d35df3e3638dfd051c8600096e520f50104c14ae#subdirectory=runners/mlcube_singularity
 validators==0.18.2
 merge-args==0.1.4
-synapseclient==2.7.0
+synapseclient==4.1.1
 schema==0.7.5
 # setuptools hotfix: https://github.com/mlcommons/medperf/issues/449
 setuptools<=66.1.1


### PR DESCRIPTION
Fixes #474

## Changelog
* Upgrade synapseclient to v4.1.1
* Remove deprecated login option with username + password
* Remove deprecated login parameter: `rememberMe`
* Update UI prompt message (and include a link to generating a Synapse PAT)
* Use `raise from` for exception chaining
* Update unit tests

## Preview

**Before update**

```text
$  medperf auth synapse_login
MedPerf 0.1.0
How do you want to login?
[1] Personal Access Token
[2] Username and Password
Select an option (1 or 2): 1
access token: 

UPGRADE AVAILABLE

A more recent version of the Synapse Client (4.1.1) is available. Your version (2.7.0) can be upgraded by typing:
    pip install --upgrade synapseclient

Python Synapse Client version 4.1.1 release notes

https://python-docs.synapse.org/news/

Welcome, Verena Chung!

✅ Done!
```

**After update**

```text
$ medperf auth synapse_login
MedPerf 0.1.0
Please provide your Synapse Personal Access Token (PAT). You can generate a new PAT at https://www.synapse.org/#!PersonalAccessTokens:0
Synapse PAT: 
Welcome, Verena Chung!

✅ Done!
```

```text
$ medperf auth synapse_login --token ...
MedPerf 0.1.0
Welcome, Verena Chung!

✅ Done!
```

## Unit test results

```python
$ pytest cli/medperf/tests/commands/auth/test_synapse_login.py 
============================================= test session starts ==============================================
platform darwin -- Python 3.9.17, pytest-7.4.0, pluggy-1.2.0
rootdir: /Users/vchung/Desktop/medperf/cli
plugins: mock-1.13.0, pyfakefs-5.0.0, time-machine-2.4.0
collected 3 items                                                                                              

cli/medperf/tests/commands/auth/test_synapse_login.py ...                                                [100%]

============================================== 3 passed in 2.26s ===============================================
```