### PR TITLE
update mlcube: fix singularity fakeroot issue

### DIFF
--- a/cli/requirements.txt
+++ b/cli/requirements.txt
@@ -10,9 +10,9 @@ colorama==0.4.4
 time-machine==2.4.0
 pytest-mock==1.13.0
 pyfakefs==5.0.0
-mlcube @ git+https://github.com/hasan7n/mlcube@d35df3e3638dfd051c8600096e520f50104c14ae#subdirectory=mlcube
-mlcube-docker @ git+https://github.com/hasan7n/mlcube@d35df3e3638dfd051c8600096e520f50104c14ae#subdirectory=runners/mlcube_docker
-mlcube-singularity @ git+https://github.com/hasan7n/mlcube@d35df3e3638dfd051c8600096e520f50104c14ae#subdirectory=runners/mlcube_singularity
+mlcube @ git+https://github.com/hasan7n/mlcube@11632a85064f653e6c5a59e3c6a4996ab9fe510b#subdirectory=mlcube
+mlcube-docker @ git+https://github.com/hasan7n/mlcube@11632a85064f653e6c5a59e3c6a4996ab9fe510b#subdirectory=runners/mlcube_docker
+mlcube-singularity @ git+https://github.com/hasan7n/mlcube@11632a85064f653e6c5a59e3c6a4996ab9fe510b#subdirectory=runners/mlcube_singularity
 validators==0.18.2
 merge-args==0.1.4
 synapseclient==2.7.0


### PR DESCRIPTION
This PR updates the MLCube version to incorporate the `--fakeroot` fix.
`--fakeroot` was used by default for building singularity images, and was forcely used for building singularity images from docker images. Now this is fixed.