### PR TITLE
Allow MLCube to pass details on missing/extra modalities

### DIFF
--- a/scripts/monitor/rano_monitor/assets/stages.yaml
+++ b/scripts/monitor/rano_monitor/assets/stages.yaml
@@ -8,11 +8,11 @@
   docs_url: ""
 -1.1:
   status_name: MISSING_MODALITIES
-  comment: There are missing modalities. Please check the data
+  comment: # Left empty so the mlcube can overwrite it with specifics
   docs_url: ""
 -1.2:
   status_name: EXTRA MODALITIES
-  comment: There are extra modalities. Please check the data
+  comment: # Left empty so the mlcube can overwrite it with specifics
   docs_url: ""
 -1.3:
   # Obtained when a section of this stage raises an unhandled error


### PR DESCRIPTION
This is a simple PR that aligns the report generation on the side of RANO's Data Preparation MLCube to the stages being used by the monitoring tool. Now, The Data Preparation MLCube provides a helpful message when someone encounters the missing or extra modalities error.