### PR TITLE
Fix compatibility tests bug with local mlcubes

### DIFF
--- a/cli/medperf/commands/compatibility_test/utils.py
+++ b/cli/medperf/commands/compatibility_test/utils.py
@@ -1,6 +1,6 @@
 from medperf.commands.dataset.prepare import DataPreparation
 from medperf.commands.dataset.submit import DataCreation
-from medperf.utils import get_folders_hash, remove_path
+from medperf.utils import get_file_hash, get_folders_hash, remove_path
 from medperf.exceptions import InvalidArgumentError, InvalidEntityError
 
 from medperf.comms.entity_resources import resources
@@ -48,11 +48,13 @@ def prepare_local_cube(path):
     config.tmp_paths.append(dst)
     cube_metadata_file = os.path.join(path, config.cube_metadata_filename)
     if not os.path.exists(cube_metadata_file):
+        mlcube_yaml_path = os.path.join(path, config.cube_filename)
+        mlcube_yaml_hash = get_file_hash(mlcube_yaml_path)
         temp_metadata = {
             "id": None,
             "name": temp_uid,
             "git_mlcube_url": "mock_url",
-            "mlcube_hash": "",
+            "mlcube_hash": mlcube_yaml_hash,
             "parameters_hash": "",
             "image_tarball_hash": "",
             "additional_files_tarball_hash": "",
@@ -88,9 +90,11 @@ def prepare_cube(cube_uid: str):
     path = path.resolve()
 
     if os.path.exists(path):
-        logging.info("local path provided. Creating symbolic link")
-        temp_uid = prepare_local_cube(path)
-        return temp_uid
+        mlcube_yaml_path = os.path.join(path, config.cube_filename)
+        if os.path.exists(mlcube_yaml_path):
+            logging.info("local path provided. Creating symbolic link")
+            temp_uid = prepare_local_cube(path)
+            return temp_uid
 
     logging.error(f"mlcube {cube_uid} was not found as an existing mlcube")
     raise InvalidArgumentError(


### PR DESCRIPTION
In compatibility tests, we allow the usage of local mlcubes (i.e., a path to a local folder containing an mlcube.yaml file). The client in this case will create a mock mlcube metadata file, specifying a mock URL corresponding to the existing `mlcube.yaml` file. 
Until we  merged https://github.com/mlcommons/medperf/pull/553, the code was not checking hashes of existing resources (like mlcube.yaml). After merging that PR, the code checks the hash, finds it invalid, then tries to download the file, causing it to attempt to use `mock_url`.
This PR fixes the issue by having the client calculate and store the hash of the existing mlcube.yaml file during the preparation of the mock mlcube metadata file.