### PR TITLE
Specify versions for rano monitor dependencies

### DIFF
--- a/scripts/monitor/requirements.txt
+++ b/scripts/monitor/requirements.txt
@@ -1,4 +1,4 @@
-pandas
-textual
-pyperclip
-PyYAML
+pandasv==2.1.0
+textual==0.46.0
+pyperclip==1.8.2
+PyYAML==6.0.1

--- a/scripts/monitor/requirements.txt
+++ b/scripts/monitor/requirements.txt
@@ -1,4 +1,4 @@
-pandasv==2.1.0
+pandas==2.1.0
 textual==0.46.0
 pyperclip==1.8.2
 PyYAML==6.0.1

--- a/scripts/monitor/setup.py
+++ b/scripts/monitor/setup.py
@@ -9,7 +9,7 @@ with open("requirements.txt", "r") as f:
 
 setup(
     name="rano-monitor",
-    version="0.0.0",
+    version="0.0.1",
     description="TUI for monitoring medperf datasets",
     url="https://github.com/mlcommons/medperf",
     author="MLCommons",


### PR DESCRIPTION
This PR specifies the versions for the dependencies of the rano monitoring tool, given that recent updates to the textual platform are causing issues with the progress bars