### PR TITLE
Fix Dashboard not working if initial dataset doesn't contain a progress report

### DIFF
--- a/scripts/dashboard/medperf_dashboard/get_data.py
+++ b/scripts/dashboard/medperf_dashboard/get_data.py
@@ -1,6 +1,7 @@
 import os
 import pandas as pd
 import datetime
+import numpy as np
 
 from medperf.entities.dataset import Dataset
 from medperf import config
@@ -38,6 +39,9 @@ def build_dset_df(dsets, user2institution, stages_df):
             exec_status = report["execution_status"]
             formatted_dset["execution_status"] = exec_status
             formatted_dset["progress"] = report["progress"]
+        else:
+            formatted_dset["execution_status"] = np.nan
+            formatted_dset["progress"] = np.nan
 
         formatted_dsets.append(formatted_dset)
         dsets_df = pd.DataFrame(formatted_dsets)


### PR DESCRIPTION
This PR contains a small fix to an issue related to the dashboard script, where if the first queried dashboard doesn't contain a progress report the code will throw an error. This is fixed by explicitly assigning the progress report value to nan if not present.