### PR TITLE
Specify numpy version

### DIFF
--- a/cli/requirements.txt
+++ b/cli/requirements.txt
@@ -22,6 +22,7 @@ setuptools<=66.1.1
 email-validator==2.0.0
 auth0-python==4.3.0
 pandas==2.1.0
+numpy==1.26.4
 watchdog==3.0.0
 GitPython==3.1.41
 psutil==5.9.8


### PR DESCRIPTION
This PR fixes an issue between Pandas and Numpy, by installed a version of numpy that is known to work with the version of pandas being used.