### PR TITLE
Improve Monitoring Tool UX related to annotations

### DIFF
--- a/scripts/monitor/rano_monitor/assets/shared.tcss
+++ b/scripts/monitor/rano_monitor/assets/shared.tcss
@@ -1,3 +1,11 @@
 .warning {
     border: tall $warning;
 }
+
+.tumor-status {
+    color: $success;
+}
+
+.brain-status {
+    color: $warning;
+}

--- a/scripts/monitor/rano_monitor/assets/tarball-browser.tcss
+++ b/scripts/monitor/rano_monitor/assets/tarball-browser.tcss
@@ -16,14 +16,6 @@ Button {
     background: $accent;
 }
 
-.tumor-status {
-    color: $success;
-}
-
-.brain-status {
-    color: $warning;
-}
-
 #package-btn {
     min-width: 50%;
 }

--- a/scripts/monitor/rano_monitor/dataset_browser.py
+++ b/scripts/monitor/rano_monitor/dataset_browser.py
@@ -104,6 +104,10 @@ class DatasetBrowser(App):
         subject_details = self.query_one("#details", SubjectDetails)
         subject_details.set_invalid_path(self.invalid_path)
 
+        # Set dataset path to listview
+        listview = self.query_one("#subjects-list", ListView)
+        listview.dset_path = self.dset_data_path
+
         # Execute handlers
         self.prompt_watchdog.manual_execute()
         self.invalid_watchdog.manual_execute()

--- a/scripts/monitor/rano_monitor/utils.py
+++ b/scripts/monitor/rano_monitor/utils.py
@@ -388,6 +388,7 @@ def unpackage_reviews(file, app, dset_data_path):
                 delete(target_file, dset_data_path)
             tar.extract(member, dest)
 
+
 def brain_has_been_reviewed(brainpath, backup_brainpath):
     if not os.path.exists(backup_brainpath):
         return False
@@ -396,14 +397,17 @@ def brain_has_been_reviewed(brainpath, backup_brainpath):
     backup_hash = get_hash(backup_brainpath)
     return brain_hash != backup_hash
 
+
 def tumor_has_been_finalized(finalized_tumor_path):
     finalized_files = os.listdir(finalized_tumor_path)
     finalized_files = [file for file in finalized_files if not file.startswith(".")]
 
     return len(finalized_files) > 0
 
+
 def can_review(subject):
     return MANUAL_REVIEW_STAGE <= abs(subject["status"]) < DONE_STAGE
+
 
 def get_finalized_tumor_path(subject: str, dset_path: str) -> str:
     """Get's the path to the finalized tumor path based solely on the
@@ -426,6 +430,7 @@ def get_finalized_tumor_path(subject: str, dset_path: str) -> str:
         "TumorMasksForQC",
         "finalized",
     )
+
 
 def get_brainmask_path(subject: str, dset_path: str) -> str:
     id, tp = subject.split("|")

--- a/scripts/monitor/rano_monitor/utils.py
+++ b/scripts/monitor/rano_monitor/utils.py
@@ -387,3 +387,53 @@ def unpackage_reviews(file, app, dset_data_path):
             if os.path.exists(target_file):
                 delete(target_file, dset_data_path)
             tar.extract(member, dest)
+
+def brain_has_been_reviewed(brainpath, backup_brainpath):
+    if not os.path.exists(backup_brainpath):
+        return False
+
+    brain_hash = get_hash(brainpath)
+    backup_hash = get_hash(backup_brainpath)
+    return brain_hash != backup_hash
+
+def tumor_has_been_finalized(finalized_tumor_path):
+    finalized_files = os.listdir(finalized_tumor_path)
+    finalized_files = [file for file in finalized_files if not file.startswith(".")]
+
+    return len(finalized_files) > 0
+
+def can_review(subject):
+    return MANUAL_REVIEW_STAGE <= abs(subject["status"]) < DONE_STAGE
+
+def get_finalized_tumor_path(subject: str, dset_path: str) -> str:
+    """Get's the path to the finalized tumor path based solely on the
+    subject identifier and data path. Works regardless of wether the subject is in
+    that stage or the folder being pointed to exists or not.
+
+    Args:
+        subject (str): subject identified, written as {subject}|{timepoint}
+
+    Returns:
+        str: _description_
+    """
+    id, tp = subject.split("|")
+    return os.path.join(
+        dset_path,
+        "tumor_extracted",
+        "DataForQC",
+        id,
+        tp,
+        "TumorMasksForQC",
+        "finalized",
+    )
+
+def get_brainmask_path(subject: str, dset_path: str) -> str:
+    id, tp = subject.split("|")
+    return os.path.join(
+        dset_path,
+        "tumor_extracted",
+        "DataForQC",
+        id,
+        tp,
+        BRAINMASK,
+    )

--- a/scripts/monitor/rano_monitor/widgets/subject_details.py
+++ b/scripts/monitor/rano_monitor/widgets/subject_details.py
@@ -3,7 +3,6 @@ import os
 import pandas as pd
 from rano_monitor.constants import (
     DEFAULT_SEGMENTATION,
-    DONE_STAGE,
     MANUAL_REVIEW_STAGE,
 )
 from rano_monitor.messages import InvalidSubjectsUpdated
@@ -14,6 +13,7 @@ from rano_monitor.utils import (
     review_brain,
     review_tumor,
     to_local_path,
+    can_review,
 )
 from rano_monitor.widgets.copyable_item import CopyableItem
 from textual.app import ComposeResult
@@ -118,8 +118,7 @@ class SubjectDetails(Static):
         # This SHOULD NOT be here for general data prep monitoring.
         # Additional configuration must be set
         # to make this kind of features generic
-        can_review = MANUAL_REVIEW_STAGE <= abs(subject["status"]) < DONE_STAGE
-        buttons_container.display = "block" if can_review else "none"
+        buttons_container.display = "block" if can_review(subject) else "none"
 
         # Only display finalize button for the manual review
         can_finalize = abs(subject["status"]) == MANUAL_REVIEW_STAGE

--- a/scripts/monitor/rano_monitor/widgets/subject_list_view.py
+++ b/scripts/monitor/rano_monitor/widgets/subject_list_view.py
@@ -1,13 +1,21 @@
+import os
 import pandas as pd
 from rano_monitor.messages import InvalidSubjectsUpdated
 from rano_monitor.messages.report_updated import ReportUpdated
 from textual.widgets import Label, ListItem, ListView
+from rano_monitor.utils import (
+    get_hash,
+    tumor_has_been_finalized,
+    get_finalized_tumor_path,
+    get_brainmask_path,
+)
 
 
 class SubjectListView(ListView):
     report = {}
     highlight = set()
     invalid_subjects = set()
+    dset_path = ""
 
     def on_report_updated(self, message: ReportUpdated) -> None:
         self.report = message.report
@@ -38,12 +46,30 @@ class SubjectListView(ListView):
             else:
                 status = report_df.loc[subject]["status_name"]
                 status = status.capitalize().replace("_", " ")
+                status_code = report_df.loc[subject]["status"]
                 if subject in self.invalid_subjects:
                     status = "Invalidated"
-                widget = ListItem(
+
+                list_contents = [
                     Label(subject),
                     Label(status, classes="subtitle"),
-                )
+                ]
+
+                tumor_path = get_finalized_tumor_path(subject, self.dset_path)
+                if os.path.exists(tumor_path) and tumor_has_been_finalized(tumor_path):
+                    list_contents.append(
+                        Label("Tumor finalized", classes="tumor-status")
+                    )
+
+                brain_path = get_brainmask_path(subject, self.dset_path)
+                exp_hash = report_df.loc[subject]["brain_mask_hash"]
+                if os.path.exists(brain_path) and get_hash(brain_path) != exp_hash:
+                    list_contents.append(
+                        Label("Brain Mask Modified", classes="brain-status")
+                    )
+
+                widget = ListItem(*list_contents)
+
             if subject in self.highlight:
                 widget.set_class(True, "highlight")
             widgets.append(widget)

--- a/scripts/monitor/rano_monitor/widgets/subject_list_view.py
+++ b/scripts/monitor/rano_monitor/widgets/subject_list_view.py
@@ -46,7 +46,6 @@ class SubjectListView(ListView):
             else:
                 status = report_df.loc[subject]["status_name"]
                 status = status.capitalize().replace("_", " ")
-                status_code = report_df.loc[subject]["status"]
                 if subject in self.invalid_subjects:
                     status = "Invalidated"
 

--- a/scripts/monitor/rano_monitor/widgets/summary.py
+++ b/scripts/monitor/rano_monitor/widgets/summary.py
@@ -25,7 +25,8 @@ class Summary(Static):
         yield Static("Report Status")
         yield Static(
             "HINT: To move forward with finalized annotations, ensure the preparation pipeline is running.",
-            id="hint-msg"
+            id="hint-msg",
+            classes="warning"
         )
         yield Center(id="summary-content")
         with Center(id="package-btns"):

--- a/scripts/monitor/rano_monitor/widgets/summary.py
+++ b/scripts/monitor/rano_monitor/widgets/summary.py
@@ -23,6 +23,10 @@ class Summary(Static):
 
     def compose(self) -> ComposeResult:
         yield Static("Report Status")
+        yield Static(
+            "HINT: To move forward with finalized annotations, ensure the preparation pipeline is running.",
+            id="hint-msg"
+        )
         yield Center(id="summary-content")
         with Center(id="package-btns"):
             yield Button(
@@ -49,6 +53,7 @@ class Summary(Static):
         if report_df.empty:
             return
         package_btns = self.query_one("#package-btns", Center)
+        hint_msg = self.query_one("#hint-msg", Static)
         # Generate progress bars for all states
         display_report_df = report_df.copy(deep=True)
         display_report_df.loc[list(self.invalid_subjects), "status_name"] = (
@@ -61,6 +66,7 @@ class Summary(Static):
             status_percents["DONE"] = 0.0
 
         package_btns.display = "MANUAL_REVIEW_REQUIRED" in status_percents
+        hint_msg.display = package_btns.display
 
         widgets = []
         for name, val in status_percents.items():

--- a/scripts/monitor/rano_monitor/widgets/tarball_subject_view.py
+++ b/scripts/monitor/rano_monitor/widgets/tarball_subject_view.py
@@ -1,10 +1,6 @@
 import os
 
-from rano_monitor.constants import (
-    BRAINMASK,
-    BRAINMASK_BAK,
-    DEFAULT_SEGMENTATION
-)
+from rano_monitor.constants import BRAINMASK, BRAINMASK_BAK, DEFAULT_SEGMENTATION
 from rano_monitor.utils import (
     finalize,
     is_editor_installed,
@@ -28,10 +24,7 @@ class TarballSubjectView(Static):
             with Container(classes="subject-text"):
                 yield Static(self.subject)
                 yield Static("Brain mask modified", classes="brain-status")
-                yield Static(
-                    "Tumor segmentation reviewed",
-                    classes="tumor-status"
-                )
+                yield Static("Tumor segmentation reviewed", classes="tumor-status")
 
             yield Button("Review Brain Mask", classes="brain-btn")
             yield Button("Review Tumor Segmentation", classes="tumor-btn")
@@ -56,7 +49,7 @@ class TarballSubjectView(Static):
     def update_status(self):
         tumor_status = self.query_one(".tumor-status", Static)
         brain_status = self.query_one(".brain-status", Static)
-        
+
         id, tp = self.subject.split("|")
         finalized_tumor_path = os.path.join(self.contents_path, id, tp, "finalized")
         brainpath = os.path.join(self.contents_path, id, tp, BRAINMASK)

--- a/scripts/monitor/setup.py
+++ b/scripts/monitor/setup.py
@@ -9,7 +9,7 @@ with open("requirements.txt", "r") as f:
 
 setup(
     name="rano-monitor",
-    version="0.0.1",
+    version="0.0.2",
     description="TUI for monitoring medperf datasets",
     url="https://github.com/mlcommons/medperf",
     author="MLCommons",


### PR DESCRIPTION
This PR adds a few QOL improvements to the annotation procedure. It does so by:
- Displaying when a subject contains finalized annotations
- Displaying when a subject's brain mask has been modified
- Displaying a hint on the summary indicating the user they have to run the pipeline to proceed after annotations

These have been points of confusion for several users, thinking their changes have not been taken into account because the monitoring tool doesn't update until the pipeline is running. This PR should improve that experience.