### PR TITLE
Allow passing itksnap path/command as an argument for the monitoring tool

### DIFF
--- a/scripts/monitor/rano_monitor/__main__.py
+++ b/scripts/monitor/rano_monitor/__main__.py
@@ -50,7 +50,7 @@ def run_dset_app(dset_path, stages_path, output_path, review_cmd):
         invalid_path,
         invalid_watchdog,
         prompt_watchdog,
-        review_cmd
+        review_cmd,
     )
 
     observer = Observer()
@@ -97,7 +97,9 @@ def main(
         help=DSET_LOC_HELP,
     ),
     output_path: str = Option(None, "-o", "--out", help=OUT_HELP),
-    itksnap_executable: str = Option(REVIEW_COMMAND, "-i", "--itksnap", help=REVIEW_CMD_HELP),
+    itksnap_executable: str = Option(
+        REVIEW_COMMAND, "-i", "--itksnap", help=REVIEW_CMD_HELP
+    ),
 ):
     if dataset_uid.endswith(".tar.gz"):
         # TODO: implement tarball_app

--- a/scripts/monitor/rano_monitor/__main__.py
+++ b/scripts/monitor/rano_monitor/__main__.py
@@ -8,6 +8,8 @@ from rano_monitor.constants import (
     STAGES_HELP,
     DSET_LOC_HELP,
     OUT_HELP,
+    REVIEW_COMMAND,
+    REVIEW_CMD_HELP,
 )
 from rano_monitor.dataset_browser import DatasetBrowser
 from rano_monitor.handlers import InvalidHandler
@@ -21,7 +23,7 @@ from watchdog.observers import Observer
 app = typer.Typer()
 
 
-def run_dset_app(dset_path, stages_path, output_path):
+def run_dset_app(dset_path, stages_path, output_path, review_cmd):
     report_path = os.path.join(dset_path, "report.yaml")
     dset_data_path = os.path.join(dset_path, "data")
     invalid_path = os.path.join(dset_path, "metadata/.invalid.txt")
@@ -48,6 +50,7 @@ def run_dset_app(dset_path, stages_path, output_path):
         invalid_path,
         invalid_watchdog,
         prompt_watchdog,
+        review_cmd
     )
 
     observer = Observer()
@@ -60,7 +63,7 @@ def run_dset_app(dset_path, stages_path, output_path):
     observer.stop()
 
 
-def run_tarball_app(tarball_path):
+def run_tarball_app(tarball_path, review_cmd):
     folder_name = f".{os.path.basename(tarball_path).split('.')[0]}"
     contents_path = os.path.join(os.path.dirname(tarball_path), folder_name)
     if not os.path.exists(contents_path):
@@ -72,7 +75,7 @@ def run_tarball_app(tarball_path):
     contents_path = os.path.join(contents_path, "review_cases")
     reviewed_watchdog = TarballReviewedHandler(contents_path, t_app)
 
-    t_app.set_vars(contents_path)
+    t_app.set_vars(contents_path, review_cmd)
 
     observer = Observer()
     observer.schedule(reviewed_watchdog, path=contents_path, recursive=True)
@@ -94,10 +97,11 @@ def main(
         help=DSET_LOC_HELP,
     ),
     output_path: str = Option(None, "-o", "--out", help=OUT_HELP),
+    itksnap_executable: str = Option(REVIEW_COMMAND, "-i", "--itksnap", help=REVIEW_CMD_HELP),
 ):
     if dataset_uid.endswith(".tar.gz"):
         # TODO: implement tarball_app
-        run_tarball_app(dataset_uid)
+        run_tarball_app(dataset_uid, itksnap_executable)
         return
     elif dataset_uid.isdigit():
         # Only import medperf dependencies if the user intends to use medperf
@@ -115,7 +119,7 @@ def main(
             "Please ensure the passed dataset UID/path is correct"
         )
 
-    run_dset_app(dset_path, stages_path, output_path)
+    run_dset_app(dset_path, stages_path, output_path, itksnap_executable)
 
 
 if __name__ == "__main__":

--- a/scripts/monitor/rano_monitor/constants.py
+++ b/scripts/monitor/rano_monitor/constants.py
@@ -24,6 +24,7 @@ BRAINMASK_BAK = ".brainMask_fused.nii.gz"
 REVIEW_FILENAME = "review_cases.tar.gz"
 REVIEWED_FILENAME = "reviewed_cases.tar.gz"
 REVIEW_COMMAND = "itksnap"
+REVIEW_CMD_HELP = f"path or name of the command that launches itksnap. Defaults to '{REVIEW_COMMAND}'"
 MANUAL_REVIEW_STAGE = 5
 DONE_STAGE = 8
 LISTITEM_MAX_LEN = 30

--- a/scripts/monitor/rano_monitor/dataset_browser.py
+++ b/scripts/monitor/rano_monitor/dataset_browser.py
@@ -46,6 +46,7 @@ class DatasetBrowser(App):
         invalid_path,
         invalid_watchdog,
         prompt_watchdog,
+        review_cmd,
     ):
         self.dset_data_path = dset_data_path
         self.stages_path = stages_path
@@ -53,6 +54,7 @@ class DatasetBrowser(App):
         self.invalid_path = invalid_path
         self.invalid_watchdog = invalid_watchdog
         self.prompt_watchdog = prompt_watchdog
+        self.review_cmd = review_cmd
 
     def update_invalid(self, invalid_subjects):
         self.invalid_subjects = invalid_subjects
@@ -103,6 +105,7 @@ class DatasetBrowser(App):
         # Set invalid path for subject view
         subject_details = self.query_one("#details", SubjectDetails)
         subject_details.set_invalid_path(self.invalid_path)
+        subject_details.review_cmd = self.review_cmd
 
         # Execute handlers
         self.prompt_watchdog.manual_execute()

--- a/scripts/monitor/rano_monitor/tarball_browser.py
+++ b/scripts/monitor/rano_monitor/tarball_browser.py
@@ -56,7 +56,9 @@ class TarballBrowser(App):
         for subject in subjects:
             subject_path = os.path.join(self.contents_path, subject)
             timepoints = os.listdir(subject_path)
-            timepoints = [timepoint for timepoint in timepoints if not timepoint.startswith(".")]
+            timepoints = [
+                timepoint for timepoint in timepoints if not timepoint.startswith(".")
+            ]
             subject_timepoint_list += [(subject, tp) for tp in timepoints]
 
         return subject_timepoint_list

--- a/scripts/monitor/rano_monitor/tarball_browser.py
+++ b/scripts/monitor/rano_monitor/tarball_browser.py
@@ -44,8 +44,9 @@ class TarballBrowser(App):
 
     subjects = var([])
 
-    def set_vars(self, contents_path):
+    def set_vars(self, contents_path, review_cmd):
         self.contents_path = contents_path
+        self.review_cmd = review_cmd
         self.subjects_list = self.__get_subjects()
 
     def __get_subjects(self):
@@ -76,6 +77,7 @@ class TarballBrowser(App):
                     subject_view = TarballSubjectView()
                     subject_view.subject = f"{id}|{tp}"
                     subject_view.contents_path = self.contents_path
+                    subject_view.review_cmd = self.review_cmd
                     yield subject_view
 
     def on_mount(self):
@@ -84,7 +86,7 @@ class TarballBrowser(App):
     def update_subjects_status(self):
         subject_views = self.query(TarballSubjectView)
         editor_msg = self.query_one("#review-msg", Static)
-        editor_msg.display = "none" if is_editor_installed() else "block"
+        editor_msg.display = "none" if is_editor_installed(self.review_cmd) else "block"
 
         for subject_view in subject_views:
             subject_view.update_status()

--- a/scripts/monitor/rano_monitor/utils.py
+++ b/scripts/monitor/rano_monitor/utils.py
@@ -9,7 +9,6 @@ from subprocess import DEVNULL, Popen
 import pandas as pd
 import yaml
 from rano_monitor.constants import (
-    REVIEW_COMMAND,
     BRAINMASK_BAK,
     DEFAULT_SEGMENTATION,
     BRAINMASK,

--- a/scripts/monitor/rano_monitor/utils.py
+++ b/scripts/monitor/rano_monitor/utils.py
@@ -34,7 +34,7 @@ def get_hash(filepath: str):
     return file_hash
 
 
-def run_editor(t1c, flair, t2, t1, seg, label, cmd=REVIEW_COMMAND):
+def run_editor(t1c, flair, t2, t1, seg, label, cmd):
     review_cmd = "{cmd} -g {t1c} -o {flair} {t2} {t1} -s {seg} -l {label}"
     review_cmd = review_cmd.format(
         cmd=cmd,
@@ -49,7 +49,7 @@ def run_editor(t1c, flair, t2, t1, seg, label, cmd=REVIEW_COMMAND):
 
 
 def review_tumor(
-    subject: str, data_path: str, labels_path: str, review_cmd: str = REVIEW_COMMAND
+    subject: str, data_path: str, labels_path: str, review_cmd: str
 ):
     (
         t1c_file,
@@ -78,7 +78,7 @@ def review_tumor(
     )
 
 
-def review_brain(subject, labels_path, data_path=None, review_cmd=REVIEW_COMMAND):
+def review_brain(subject, labels_path, review_cmd, data_path=None):
     (
         t1c_file,
         t1n_file,

--- a/scripts/monitor/rano_monitor/utils.py
+++ b/scripts/monitor/rano_monitor/utils.py
@@ -22,8 +22,8 @@ from rano_monitor.constants import (
 )
 
 
-def is_editor_installed():
-    review_command_path = shutil.which(REVIEW_COMMAND)
+def is_editor_installed(review_command):
+    review_command_path = shutil.which(review_command)
     return review_command_path is not None
 
 
@@ -37,7 +37,7 @@ def get_hash(filepath: str):
 def run_editor(t1c, flair, t2, t1, seg, label, cmd=REVIEW_COMMAND):
     review_cmd = "{cmd} -g {t1c} -o {flair} {t2} {t1} -s {seg} -l {label}"
     review_cmd = review_cmd.format(
-        cmd=REVIEW_COMMAND,
+        cmd=cmd,
         t1c=t1c,
         flair=flair,
         t2=t2,
@@ -48,7 +48,7 @@ def run_editor(t1c, flair, t2, t1, seg, label, cmd=REVIEW_COMMAND):
     Popen(review_cmd.split(), shell=False, stdout=DEVNULL, stderr=DEVNULL)
 
 
-def review_tumor(subject: str, data_path: str, labels_path: str):
+def review_tumor(subject: str, data_path: str, labels_path: str, review_cmd: str = REVIEW_COMMAND):
     (
         t1c_file,
         t1n_file,
@@ -65,10 +65,10 @@ def review_tumor(subject: str, data_path: str, labels_path: str):
     if not is_nifti and not is_under_review:
         shutil.copyfile(seg_file, under_review_file)
 
-    run_editor(t1c_file, t2f_file, t2w_file, t1n_file, under_review_file, label_file)
+    run_editor(t1c_file, t2f_file, t2w_file, t1n_file, under_review_file, label_file, cmd=review_cmd)
 
 
-def review_brain(subject, labels_path, data_path=None):
+def review_brain(subject, labels_path, data_path=None, review_cmd=REVIEW_COMMAND):
     (
         t1c_file,
         t1n_file,
@@ -82,7 +82,7 @@ def review_brain(subject, labels_path, data_path=None):
     if not os.path.exists(backup_path):
         shutil.copyfile(seg_file, backup_path)
 
-    run_editor(t1c_file, t2f_file, t2w_file, t1n_file, seg_file, label_file)
+    run_editor(t1c_file, t2f_file, t2w_file, t1n_file, seg_file, label_file, cmd=review_cmd)
 
 
 def finalize(subject: str, labels_path: str):

--- a/scripts/monitor/rano_monitor/utils.py
+++ b/scripts/monitor/rano_monitor/utils.py
@@ -48,7 +48,9 @@ def run_editor(t1c, flair, t2, t1, seg, label, cmd=REVIEW_COMMAND):
     Popen(review_cmd.split(), shell=False, stdout=DEVNULL, stderr=DEVNULL)
 
 
-def review_tumor(subject: str, data_path: str, labels_path: str, review_cmd: str = REVIEW_COMMAND):
+def review_tumor(
+    subject: str, data_path: str, labels_path: str, review_cmd: str = REVIEW_COMMAND
+):
     (
         t1c_file,
         t1n_file,
@@ -65,7 +67,15 @@ def review_tumor(subject: str, data_path: str, labels_path: str, review_cmd: str
     if not is_nifti and not is_under_review:
         shutil.copyfile(seg_file, under_review_file)
 
-    run_editor(t1c_file, t2f_file, t2w_file, t1n_file, under_review_file, label_file, cmd=review_cmd)
+    run_editor(
+        t1c_file,
+        t2f_file,
+        t2w_file,
+        t1n_file,
+        under_review_file,
+        label_file,
+        cmd=review_cmd,
+    )
 
 
 def review_brain(subject, labels_path, data_path=None, review_cmd=REVIEW_COMMAND):
@@ -82,7 +92,9 @@ def review_brain(subject, labels_path, data_path=None, review_cmd=REVIEW_COMMAND
     if not os.path.exists(backup_path):
         shutil.copyfile(seg_file, backup_path)
 
-    run_editor(t1c_file, t2f_file, t2w_file, t1n_file, seg_file, label_file, cmd=review_cmd)
+    run_editor(
+        t1c_file, t2f_file, t2w_file, t1n_file, seg_file, label_file, cmd=review_cmd
+    )
 
 
 def finalize(subject: str, labels_path: str):

--- a/scripts/monitor/rano_monitor/widgets/subject_details.py
+++ b/scripts/monitor/rano_monitor/widgets/subject_details.py
@@ -25,6 +25,7 @@ class SubjectDetails(Static):
     invalid_subjects = set()
     subject = pd.Series()
     dset_path = ""
+    review_cmd = None # This will be assigned after initialized
 
     def compose(self) -> ComposeResult:
         with Center(id="subject-title"):
@@ -135,7 +136,7 @@ class SubjectDetails(Static):
         brainmask_button = self.query_one("#brainmask-review-button", Button)
         valid_btn = self.query_one("#valid-btn", Button)
 
-        if is_editor_installed():
+        if is_editor_installed(self.review_cmd):
             review_msg.display = "none"
             review_button.disabled = False
         if self.__can_finalize():
@@ -176,7 +177,7 @@ class SubjectDetails(Static):
         data_path = to_local_path(data_path, self.dset_path)
         labels_path = self.subject["labels_path"]
         labels_path = to_local_path(labels_path, self.dset_path)
-        review_tumor(subject, data_path, labels_path)
+        review_tumor(subject, data_path, labels_path, review_cmd=self.review_cmd)
         self.__update_buttons()
         self.notify("This subject can be finalized now")
 
@@ -184,7 +185,7 @@ class SubjectDetails(Static):
         subject = self.subject.name
         labels_path = self.subject["labels_path"]
         labels_path = to_local_path(labels_path, self.dset_path)
-        review_brain(subject, labels_path)
+        review_brain(subject, labels_path, review_cmd=self.review_cmd)
         self.__update_buttons()
 
     def __finalize(self):

--- a/scripts/monitor/rano_monitor/widgets/subject_details.py
+++ b/scripts/monitor/rano_monitor/widgets/subject_details.py
@@ -25,7 +25,7 @@ class SubjectDetails(Static):
     invalid_subjects = set()
     subject = pd.Series()
     dset_path = ""
-    review_cmd = None # This will be assigned after initialized
+    review_cmd = None  # This will be assigned after initialized
 
     def compose(self) -> ComposeResult:
         with Center(id="subject-title"):
@@ -52,10 +52,7 @@ class SubjectDetails(Static):
                 id="reviewed-button",
                 disabled=True,
             )
-            yield Static(
-                "If brain mask is not correct",
-                id="brianmask-review-header"
-            )
+            yield Static("If brain mask is not correct", id="brianmask-review-header")
             yield Button(
                 "Brain mask not available",
                 disabled=True,

--- a/scripts/monitor/rano_monitor/widgets/tarball_subject_view.py
+++ b/scripts/monitor/rano_monitor/widgets/tarball_subject_view.py
@@ -21,6 +21,7 @@ from textual.widgets import Button, Static
 class TarballSubjectView(Static):
     subject = reactive("")
     contents_path = reactive("")
+    review_cmd = None # This will be assigned after initialized
 
     def compose(self) -> ComposeResult:
         with Horizontal(classes="subject-item"):
@@ -64,7 +65,7 @@ class TarballSubjectView(Static):
         tumor_btn = self.query_one(".tumor-btn", Button)
         finalize_btn = self.query_one(".finalize-btn", Button)
         brain_btn = self.query_one(".brain-btn", Button)
-        if is_editor_installed():
+        if is_editor_installed(self.review_cmd):
             tumor_btn.disabled = False
         if self.__can_finalize():
             finalize_btn.disabled = False
@@ -87,19 +88,19 @@ class TarballSubjectView(Static):
         id, tp = self.subject.split("|")
         filepath = os.path.join(self.contents_path, id, tp, BRAINMASK)
 
-        return os.path.exists(filepath) and is_editor_installed()
+        return os.path.exists(filepath) and is_editor_installed(self.review_cmd)
 
     def __review_tumor(self):
         id, tp = self.subject.split("|")
         data_path = os.path.join(self.contents_path, id, tp, "brain_scans")
         labels_path = os.path.join(self.contents_path, id, tp)
-        review_tumor(self.subject, data_path, labels_path)
+        review_tumor(self.subject, data_path, labels_path, review_cmd=self.review_cmd)
 
     def __review_brainmask(self):
         id, tp = self.subject.split("|")
         data_path = os.path.join(self.contents_path, id, tp, "raw_scans")
         labels_path = os.path.join(self.contents_path, id, tp)
-        review_brain(self.subject, labels_path, data_path)
+        review_brain(self.subject, labels_path, data_path, review_cmd=self.review_cmd)
 
     def __finalize(self):
         id, tp = self.subject.split("|")

--- a/scripts/monitor/rano_monitor/widgets/tarball_subject_view.py
+++ b/scripts/monitor/rano_monitor/widgets/tarball_subject_view.py
@@ -1,10 +1,6 @@
 import os
 
-from rano_monitor.constants import (
-    BRAINMASK,
-    BRAINMASK_BAK,
-    DEFAULT_SEGMENTATION
-)
+from rano_monitor.constants import BRAINMASK, BRAINMASK_BAK, DEFAULT_SEGMENTATION
 from rano_monitor.utils import (
     finalize,
     get_hash,
@@ -21,17 +17,14 @@ from textual.widgets import Button, Static
 class TarballSubjectView(Static):
     subject = reactive("")
     contents_path = reactive("")
-    review_cmd = None # This will be assigned after initialized
+    review_cmd = None  # This will be assigned after initialized
 
     def compose(self) -> ComposeResult:
         with Horizontal(classes="subject-item"):
             with Container(classes="subject-text"):
                 yield Static(self.subject)
                 yield Static("Brain mask modified", classes="brain-status")
-                yield Static(
-                    "Tumor segmentation reviewed",
-                    classes="tumor-status"
-                )
+                yield Static("Tumor segmentation reviewed", classes="tumor-status")
 
             yield Button("Review Brain Mask", classes="brain-btn")
             yield Button("Review Tumor Segmentation", classes="tumor-btn")
@@ -124,12 +117,7 @@ class TarballSubjectView(Static):
     def __brain_has_been_reviewed(self):
         id, tp = self.subject.split("|")
         brainpath = os.path.join(self.contents_path, id, tp, BRAINMASK)
-        backup_brainpath = os.path.join(
-            self.contents_path,
-            id,
-            tp,
-            BRAINMASK_BAK
-        )
+        backup_brainpath = os.path.join(self.contents_path, id, tp, BRAINMASK_BAK)
 
         if not os.path.exists(backup_brainpath):
             return False
@@ -140,12 +128,7 @@ class TarballSubjectView(Static):
 
     def __tumor_has_been_finalized(self):
         id, tp = self.subject.split("|")
-        finalized_tumor_path = os.path.join(
-            self.contents_path,
-            id,
-            tp,
-            "finalized"
-        )
+        finalized_tumor_path = os.path.join(self.contents_path, id, tp, "finalized")
         finalized_files = os.listdir(finalized_tumor_path)
         finalized_files = [file for file in finalized_files if not file.startswith(".")]
 

--- a/scripts/monitor/rano_monitor/widgets/tarball_subject_view.py
+++ b/scripts/monitor/rano_monitor/widgets/tarball_subject_view.py
@@ -93,7 +93,7 @@ class TarballSubjectView(Static):
         id, tp = self.subject.split("|")
         data_path = os.path.join(self.contents_path, id, tp, "raw_scans")
         labels_path = os.path.join(self.contents_path, id, tp)
-        review_brain(self.subject, labels_path, data_path, review_cmd=self.review_cmd)
+        review_brain(self.subject, labels_path, self.review_cmd, data_path)
 
     def __finalize(self):
         id, tp = self.subject.split("|")


### PR DESCRIPTION
In a few cases, people haven't been able to run the monitoring tool because they don't have itksnap cli installed as the monitoring tool expects, and they have valid reasons for this (multiple versions of itksnap, not having permissions to move itksnap to the binary folder, etc).

This PR allows users to pass an optional argument when running the monitoring tool to define where itksnap is found.