### PR TITLE
Fix package buttons not displaying in relevant stages

### DIFF
--- a/scripts/monitor/rano_monitor/widgets/summary.py
+++ b/scripts/monitor/rano_monitor/widgets/summary.py
@@ -1,6 +1,6 @@
 import os
 import pandas as pd
-from rano_monitor.constants import REVIEW_FILENAME, REVIEWED_FILENAME
+from rano_monitor.constants import REVIEW_FILENAME, REVIEWED_FILENAME, MANUAL_REVIEW_STAGE, DONE_STAGE
 from rano_monitor.messages import InvalidSubjectsUpdated
 from rano_monitor.messages import ReportUpdated
 from rano_monitor.messages import AnnotationsLoaded
@@ -66,7 +66,10 @@ class Summary(Static):
             # Attach
             status_percents["DONE"] = 0.0
 
-        package_btns.display = "MANUAL_REVIEW_REQUIRED" in status_percents
+        abs_status = display_report_df["status"].abs()
+        is_beyond_manual_review = (abs_status >= MANUAL_REVIEW_STAGE) 
+        is_not_done = (abs_status < DONE_STAGE)
+        package_btns.display = any(is_beyond_manual_review & is_not_done)
 
         widgets = []
         for name, val in status_percents.items():

--- a/scripts/monitor/rano_monitor/widgets/summary.py
+++ b/scripts/monitor/rano_monitor/widgets/summary.py
@@ -67,7 +67,7 @@ class Summary(Static):
             status_percents["DONE"] = 0.0
 
         abs_status = display_report_df["status"].abs()
-        is_beyond_manual_review = (abs_status >= MANUAL_REVIEW_STAGE) 
+        is_beyond_manual_review = (abs_status >= MANUAL_REVIEW_STAGE)
         is_not_done = (abs_status < DONE_STAGE)
         package_btns.display = any(is_beyond_manual_review & is_not_done)
 


### PR DESCRIPTION
This PR fixes an issue where if an user's subjects are all past manual review, but on a stage where they still should be able to modify their reviews (e.g. exact match identified), they won't be able to load in new annotations because the package buttons are no longer displayed.