### PR TITLE
RANO Monitor - Package Review Cases - Handle cases where labels path is a file

### DIFF
--- a/scripts/monitor/rano_monitor/utils.py
+++ b/scripts/monitor/rano_monitor/utils.py
@@ -238,6 +238,9 @@ def package_review_cases(report: pd.DataFrame, dset_path: str):
             labels_path = to_local_path(row["labels_path"], dset_path)
             brainscans = get_tumor_review_paths(row.name, data_path, labels_path)[:-2]
             rawscans = get_brain_review_paths(row.name, labels_path)[:-1]
+            if os.path.isfile(labels_path):
+                labels_path = os.path.dirname(labels_path)
+                labels_path = os.path.join(labels_path, "..")
             base_path = os.path.join(labels_path, "..")
 
             # Add tumor segmentations

--- a/scripts/monitor/setup.py
+++ b/scripts/monitor/setup.py
@@ -9,7 +9,7 @@ with open("requirements.txt", "r") as f:
 
 setup(
     name="rano-monitor",
-    version="0.0.2",
+    version="0.0.3",
     description="TUI for monitoring medperf datasets",
     url="https://github.com/mlcommons/medperf",
     author="MLCommons",


### PR DESCRIPTION
This PR fixes an issue where packaging cases fails if any of the cases is in the comparison stage. The error happens because the labels path changes between "Manual Review Required" and subsequent steps. This PR adds logic to detect such scenario and use the correct path internally.