### PR TITLE
Check Entity ID Before Resuming a Running Task

### DIFF
--- a/cli/medperf/web_ui/static/js/datasets/dataset_detail.js
+++ b/cli/medperf/web_ui/static/js/datasets/dataset_detail.js
@@ -177,10 +177,12 @@ async function submitResult(submitResultButton){
 
     const resultId = submitResultButton.getAttribute("data-result-id");
     const benchmarkId = submitResultButton.getAttribute("data-benchmark-id");
+    const datasetId = submitResultButton.getAttribute("data-dataset-id");
     
     const formData = new FormData();
     formData.append("result_id", resultId);
     formData.append("benchmark_id", benchmarkId);
+    formData.append("dataset_id", datasetId)
 
     disableElements(".card button");
     

--- a/cli/medperf/web_ui/templates/container/container_detail.html
+++ b/cli/medperf/web_ui/templates/container/container_detail.html
@@ -177,8 +177,7 @@
 {% block extra_js %}
 <script src="{{ url_for('static', path='js/event_handler.js') }}"></script>
 <script src="{{ url_for('static', path='js/containers/container_detail.js') }}"></script>
-
-{% if task_running and request.app.state.task["name"] == "container_association" %}
+{% if task_running and request.app.state.task["name"] == "container_association" and task_formData.get("container_id", "") == entity.id|string %}
 <script>
     $(document).ready(() => {
         resumeRunningTask(

--- a/cli/medperf/web_ui/templates/dataset/dataset_detail.html
+++ b/cli/medperf/web_ui/templates/dataset/dataset_detail.html
@@ -318,6 +318,7 @@
                                         id="submit-{{ assoc }}-{{ reference_model.result.id }}"
 										data-result-id="{{ reference_model.result.id }}"
                                         data-benchmark-id="{{ assoc }}"
+                                        data-dataset-id="{{ dataset.id }}"
                                         {% if task_running %} disabled {% endif %}
 									>
 										⬆️ Submit
@@ -377,6 +378,7 @@
                                         id="submit-{{ assoc }}-{{ model.result.id }}"
                                         data-result-id="{{ model.result.id }}"
                                         data-benchmark-id="{{ assoc }}"
+                                        data-dataset-id="{{ dataset.id }}"
                                         {% if task_running %} disabled {% endif %}
                                     >
                                         ⬆️ Submit
@@ -419,7 +421,7 @@
 <script src="{{ url_for('static', path='js/results/results_utils.js') }}"></script>
 <script src="{{ url_for('static', path='js/datasets/dataset_detail.js') }}"></script>
 
-{% if task_running %}
+{% if task_running and task_formData.get("dataset_id", "") == dataset.id|string %}
 {% if request.app.state.task["name"] == "dataset_preparation" %}
 <script>
     $(document).ready(() => {

--- a/cli/medperf/web_ui/templates/dataset/export_dataset.html
+++ b/cli/medperf/web_ui/templates/dataset/export_dataset.html
@@ -187,7 +187,7 @@
 <script src="{{ url_for('static', path='js/datasets/dataset_export.js') }}"></script>
 <script src="{{ url_for('static', path='js/folder_browsing.js') }}"></script>
 
-{% if task_running and request.app.state.task["name"] == "dataset_export" %}
+{% if task_running and request.app.state.task["name"] == "dataset_export" and task_formData.get("dataset_id", "") == dataset.id|string %}
 <script>
     $(document).ready(() => {
         resumeRunningTask(

--- a/cli/medperf/web_ui/templates/dataset/import_dataset.html
+++ b/cli/medperf/web_ui/templates/dataset/import_dataset.html
@@ -150,7 +150,7 @@
 <script src="{{ url_for('static', path='js/datasets/dataset_import.js') }}"></script>
 <script src="{{ url_for('static', path='js/folder_browsing.js') }}"></script>
 
-{% if task_running and request.app.state.task["name"] == "dataset_import" %}
+{% if task_running and request.app.state.task["name"] == "dataset_import" and task_formData.get("dataset_id", "") == dataset.id|string %}
 <script>
     $(document).ready(() => {
         resumeRunningTask(


### PR DESCRIPTION
Add a check to ensure the running task's entity ID matches the current page's entity ID (e.g: prevent mismatch like task association for model ID 2 while viewing model ID 4).