### PR TITLE
Results Slider fix

### DIFF
--- a/cli/medperf/web_ui/static/js/benchmarks/benchmark_detail.js
+++ b/cli/medperf/web_ui/static/js/benchmarks/benchmark_detail.js
@@ -203,10 +203,6 @@ $(document).ready(() => {
         $("#benchmark-results").slideToggle(); // smooth animation
     });
     
-    $("#benchmark-results-title").on("click", () => {
-        $("#benchmark-results").slideToggle(); // smooth animation
-    });
-    
     $("#dataset-auto-approve-mode").on("change", (e) => {
         if(e.currentTarget.value === "ALLOWLIST"){
             $("#dataset-allow-list-container").removeClass("d-none");


### PR DESCRIPTION
This PR fixes an issue with the results slider in the web UI that was causing it to open and then close quickly when clicked. The reason was a duplicate definition of the on-click event handler.