### PR TITLE
Migrate from Pydantic v1 to v2

### DIFF
--- a/cli/medperf/asset_management/gcp_utils/types.py
+++ b/cli/medperf/asset_management/gcp_utils/types.py
@@ -1,3 +1,4 @@
+from typing import Optional
 from pydantic import BaseModel
 
 
@@ -9,7 +10,7 @@ class CCWorkloadID(BaseModel):
     data_id: int
     model_id: int
     script_id: int
-    execution_id: int = None
+    execution_id: Optional[int] = None
 
     @property
     def id(self):

--- a/cli/medperf/commands/association/utils.py
+++ b/cli/medperf/commands/association/utils.py
@@ -1,6 +1,6 @@
 from medperf.exceptions import InvalidArgumentError, MedperfException
 from medperf import config
-from pydantic.datetime_parse import parse_datetime
+from medperf.utils import parse_datetime
 
 
 def validate_args(benchmark, training_exp, dataset, model, approval_status):

--- a/cli/medperf/commands/execution/utils.py
+++ b/cli/medperf/commands/execution/utils.py
@@ -1,4 +1,4 @@
-from pydantic.datetime_parse import parse_datetime
+from medperf.utils import parse_datetime
 from medperf.entities.execution import Execution
 from typing import List
 

--- a/cli/medperf/entities/interface.py
+++ b/cli/medperf/entities/interface.py
@@ -16,7 +16,7 @@ class Entity(ABC):
 
     def __init__(self):
         self._model: MedperfSchema
-        self._fields = list(self._model.__fields__.keys())
+        self._fields = list(self._model.__class__.model_fields.keys())
         self.for_test = self._model.for_test
         self.id = self._model.id
         self.name = self._model.name
@@ -218,7 +218,7 @@ class Entity(ABC):
         return data
 
     def todict(self) -> dict:
-        return self._model.dict()
+        return self._model.model_dump()
 
     def write(self) -> str:
         """Writes the entity to the local storage

--- a/cli/medperf/entities/model.py
+++ b/cli/medperf/entities/model.py
@@ -70,13 +70,13 @@ class Model(Entity):
     def container_obj(self):
         if not self.is_container():
             raise MedperfException("Model is not a container")
-        return Cube(**self.container.dict())
+        return Cube(**self.container.model_dump())
 
     @property
     def asset_obj(self):
         if not self.is_asset():
             raise MedperfException("Model is not an asset")
-        return Asset(**self.asset.dict())
+        return Asset(**self.asset.model_dump())
 
     def is_encrypted(self) -> bool:
         return self.is_container() and self.container_obj.is_encrypted()

--- a/cli/medperf/entities/schemas.py
+++ b/cli/medperf/entities/schemas.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from pydantic import BaseModel, Field, validator
+from pydantic import BaseModel, Field, field_validator, ConfigDict
 from typing import Optional, Union
 
 from medperf.enums import Status, CryptoKeyType
@@ -7,15 +7,14 @@ from medperf.enums import Status, CryptoKeyType
 
 class MedperfSchema(BaseModel):
     for_test: Optional[bool] = False
-    id: Optional[int]
+    id: Optional[int] = None
     name: str = Field(..., max_length=128)
-    owner: Optional[int]
+    owner: Optional[int] = None
     is_valid: bool = True
-    created_at: Optional[datetime]
-    modified_at: Optional[datetime]
+    created_at: Optional[datetime] = None
+    modified_at: Optional[datetime] = None
 
-    class Config:
-        use_enum_values = True
+    model_config = ConfigDict(use_enum_values=True)
 
 
 class AggregatorSchema(MedperfSchema):
@@ -23,8 +22,9 @@ class AggregatorSchema(MedperfSchema):
     config: dict
     aggregation_mlcube: int
 
-    @validator("config", pre=True, always=True)
-    def check_config(cls, v, *, values, **kwargs):
+    @field_validator("config", mode="before")
+    @classmethod
+    def check_config(cls, v):
         keys = set(v.keys())
         allowed_keys = {"address", "port", "admin_port"}
         if keys != allowed_keys:
@@ -44,13 +44,13 @@ class AssetSchema(MedperfSchema):
 
 class BenchmarkSchema(MedperfSchema):
     state: str = "DEVELOPMENT"
-    approved_at: Optional[datetime]
-    approval_status: Status = None
+    approved_at: Optional[datetime] = None
+    approval_status: Optional[Status] = None
     description: Optional[str] = Field(None, max_length=256)
-    docs_url: Optional[str]
-    demo_dataset_tarball_url: Optional[str]
-    demo_dataset_tarball_hash: Optional[str]
-    demo_dataset_generated_uid: Optional[str]
+    docs_url: Optional[str] = None
+    demo_dataset_tarball_url: Optional[str] = None
+    demo_dataset_tarball_hash: Optional[str] = None
+    demo_dataset_generated_uid: Optional[str] = None
     data_preparation_mlcube: int
     reference_model: int
     data_evaluator_mlcube: int
@@ -70,8 +70,9 @@ class CASchema(MedperfSchema):
     ca_mlcube: int
     config: dict
 
-    @validator("config", pre=True, always=True)
-    def check_config(cls, v, *, values, **kwargs):
+    @field_validator("config", mode="before")
+    @classmethod
+    def check_config(cls, v):
         keys = set(v.keys())
         allowed_keys = {
             "address",
@@ -97,10 +98,10 @@ class CertificateSchema(MedperfSchema):
 class CubeSchema(MedperfSchema):
     state: str = "DEVELOPMENT"
     container_config: dict
-    parameters_config: Optional[dict]
-    image_hash: Optional[str]
-    additional_files_tarball_url: Optional[str]
-    additional_files_tarball_hash: Optional[str]
+    parameters_config: Optional[dict] = None
+    image_hash: Optional[str] = None
+    additional_files_tarball_url: Optional[str] = None
+    additional_files_tarball_hash: Optional[str] = None
     metadata: dict = Field(default_factory=dict)
     user_metadata: dict = Field(default_factory=dict)
 
@@ -112,7 +113,7 @@ class DatasetSchema(MedperfSchema):
     input_data_hash: str
     generated_uid: str
     data_preparation_mlcube: int
-    split_seed: Optional[int]
+    split_seed: Optional[int] = None
     generated_metadata: dict
     user_metadata: dict = {}
     report: dict = {}
@@ -129,13 +130,13 @@ class TrainingEventSchema(MedperfSchema):
     training_exp: int
     participants: dict
     finished: bool = False
-    finished_at: Optional[datetime]
-    report: Optional[dict]
+    finished_at: Optional[datetime] = None
+    report: Optional[dict] = None
 
 
 class ExecutionSchema(MedperfSchema):
-    approved_at: Optional[datetime]
-    approval_status: Status = None
+    approved_at: Optional[datetime] = None
+    approval_status: Optional[Status] = None
     benchmark: int
     model: int
     dataset: int
@@ -145,45 +146,45 @@ class ExecutionSchema(MedperfSchema):
     model_report: dict = {}
     evaluation_report: dict = {}
     finalized: bool = False
-    finalized_at: Optional[datetime]
+    finalized_at: Optional[datetime] = None
 
 
 class ModelSchema(MedperfSchema):
     state: str = "DEVELOPMENT"
     type: str  # ASSET or CONTAINER
-    container: Optional[CubeSchema]
-    asset: Optional[AssetSchema]
+    container: Optional[CubeSchema] = None
+    asset: Optional[AssetSchema] = None
     metadata: dict = {}
     user_metadata: dict = {}
 
 
 class TestReportSchema(MedperfSchema):
     name: Optional[str] = "name"
-    demo_dataset_url: Optional[str]
-    demo_dataset_hash: Optional[str]
-    prepared_data_hash: Optional[str]
-    data_preparation_mlcube: Optional[Union[int, str]]
+    demo_dataset_url: Optional[str] = None
+    demo_dataset_hash: Optional[str] = None
+    prepared_data_hash: Optional[str] = None
+    data_preparation_mlcube: Optional[Union[int, str]] = None
     model: Union[int, str]
     data_evaluator_mlcube: Union[int, str]
-    results: Optional[dict]
+    results: Optional[dict] = None
 
 
 class TrainingExpSchema(MedperfSchema):
-    approved_at: Optional[datetime]
-    approval_status: Status = None
+    approved_at: Optional[datetime] = None
+    approval_status: Optional[Status] = None
     state: str = "DEVELOPMENT"
     description: Optional[str] = Field(None, max_length=256)
-    docs_url: Optional[str]
+    docs_url: Optional[str] = None
     demo_dataset_tarball_url: str
-    demo_dataset_tarball_hash: Optional[str]
-    demo_dataset_generated_uid: Optional[str]
+    demo_dataset_tarball_hash: Optional[str] = None
+    demo_dataset_generated_uid: Optional[str] = None
     data_preparation_mlcube: int
     fl_mlcube: int
-    fl_admin_mlcube: Optional[int]
+    fl_admin_mlcube: Optional[int] = None
     plan: dict = {}
     metadata: dict = {}
     user_metadata: dict = {}
-    aggregator: Optional[int]
+    aggregator: Optional[int] = None
 
 
 class UserSchema(BaseModel):

--- a/cli/medperf/entities/user.py
+++ b/cli/medperf/entities/user.py
@@ -11,7 +11,7 @@ class User:
     @handle_validation_error
     def __init__(self, **kwargs):
         self._model = UserSchema(**kwargs)
-        self._fields = list(self._model.__fields__.keys())
+        self._fields = list(self._model.__class__.model_fields.keys())
         self.id = self._model.id
         self.username = self._model.username
         self.email = self._model.email

--- a/cli/medperf/tests/commands/benchmark/test_submit.py
+++ b/cli/medperf/tests/commands/benchmark/test_submit.py
@@ -40,7 +40,7 @@ def test_submit_prepares_tmp_path_for_cleanup():
 def test_submit_uploads_benchmark_data(mocker, result, comms, ui):
     # Arrange
     submission = SubmitBenchmark(BENCHMARK_INFO)
-    submission.bmk.metadata = {"results": result}
+    submission.bmk.metadata = {"results": {}}
     expected_data = submission.bmk.todict()
     spy_upload = mocker.patch.object(
         comms, "upload_benchmark", return_value=TestBenchmark().todict()

--- a/cli/medperf/ui/cli.py
+++ b/cli/medperf/ui/cli.py
@@ -5,11 +5,12 @@ from yaspin import yaspin
 from contextlib import contextmanager
 
 from .interface import UI
+from .utils import spinner_color
 
 
 class CLI(UI):
     def __init__(self):
-        self.spinner = yaspin(color="green")
+        self.spinner = yaspin(color=spinner_color())
         self.is_interactive = False
         self.is_parsed_output = False
 

--- a/cli/medperf/ui/utils.py
+++ b/cli/medperf/ui/utils.py
@@ -1,0 +1,8 @@
+import sys
+
+
+def spinner_color():
+    # yaspin/termcolor warn when a color is requested but the output stream is
+    # not a TTY (e.g. under pytest capture, CI logs or redirected output).
+    # Only request a color when stdout is an interactive terminal.
+    return "green" if sys.stdout.isatty() else None

--- a/cli/medperf/ui/web_ui.py
+++ b/cli/medperf/ui/web_ui.py
@@ -5,6 +5,7 @@ import typer
 
 from medperf.ui.cli import CLI
 from medperf.web_ui.schemas import Event, EventsManager, GlobalEventsManager
+from .utils import spinner_color
 
 
 class WebUI(CLI):
@@ -12,7 +13,7 @@ class WebUI(CLI):
         super().__init__()
         self.responses: Queue[dict] = Queue()
         self.is_interactive = False
-        self.spinner = yaspin(color="green")
+        self.spinner = yaspin(color=spinner_color())
         self.task_id = None
         self.events_manager = EventsManager()
         self.global_events_manager = GlobalEventsManager()

--- a/cli/medperf/utils.py
+++ b/cli/medperf/utils.py
@@ -17,13 +17,18 @@ from pathlib import Path
 import shutil
 from pexpect import spawn
 from datetime import datetime
-from typing import List
+from typing import List, Union
 from colorama import Fore, Style
 from pexpect.exceptions import TIMEOUT
 from git import Repo, GitCommandError
 import medperf.config as config
-from medperf.exceptions import CleanExit, ExecutionError, InvalidArgumentError
+from medperf.exceptions import (
+    CleanExit,
+    ExecutionError,
+    InvalidArgumentError,
+)
 import shlex
+from pydantic import TypeAdapter
 from email_validator import validate_email, EmailNotValidError
 from medperf.enums import CryptoKeyType
 
@@ -738,3 +743,18 @@ def validate_and_normalize_emails(emails: list[str]):
             logging.debug(f"Invalid email: |{email}|")
             raise InvalidArgumentError(str(e))
     return emails
+
+
+def parse_datetime(datetime_obj: Union[str, int, datetime]):
+    # Pydantic v2 way of implementing old parse_datetime functionality.
+    # Adapted from https://github.com/pydantic/pydantic/discussions/6204#discussioncomment-6266717
+
+    if isinstance(datetime_obj, datetime):
+        return datetime_obj
+    elif isinstance(datetime_obj, (str, int)):
+        return TypeAdapter(datetime).validate_strings(str(datetime_obj))
+    else:
+        raise ValueError(
+            "Current implementation of parse_datetime only supports strings, ints and datetimes!\n"
+            f"Object sent was of type {type(datetime_obj)}\n{datetime_obj=}"
+        )

--- a/cli/medperf/web_ui/common.py
+++ b/cli/medperf/web_ui/common.py
@@ -11,7 +11,7 @@ from urllib.parse import urlparse
 from fastapi.requests import Request
 from medperf import config
 from starlette.responses import RedirectResponse
-from pydantic.datetime_parse import parse_datetime
+from medperf.utils import parse_datetime
 
 from medperf.enums import Status
 from medperf.web_ui.auth import (

--- a/cli/medperf/web_ui/containers/routes.py
+++ b/cli/medperf/web_ui/containers/routes.py
@@ -146,7 +146,7 @@ def register_container(
             container_info,
             container_config=container_file,
             parameters_config=parameters_file,
-            decryption_key=decryption_file,
+            decryption_key=decryption_file or None,
         )
         return_response["status"] = "success"
         return_response["entity_id"] = container_id

--- a/cli/medperf/web_ui/events.py
+++ b/cli/medperf/web_ui/events.py
@@ -51,7 +51,7 @@ def process_event(request: Request, event: EventBase):
 
 
 def sse_frame_event(event: EventBase):
-    return f"id: {event.id}\ndata: {event.json()}\n\n"
+    return f"id: {event.id}\ndata: {event.model_dump_json()}\n\n"
 
 
 def should_process_old(request: Request, stream_old: bool):
@@ -107,11 +107,11 @@ def global_event_generator(request: Request):
         try:
             notification = config.ui.get_notification()
             if notification:
-                yield f"id: {notification.id}\nevent: notification\ndata: {notification.json()}\n\n"
+                yield f"id: {notification.id}\nevent: notification\ndata: {notification.model_dump_json()}\n\n"
 
             event = config.ui.get_global_event()
             if event:
-                yield f"id: {event.id}\nevent: event\ndata: {event.json()}\n\n"
+                yield f"id: {event.id}\nevent: event\ndata: {event.model_dump_json()}\n\n"
 
         except (BrokenPipeError, ConnectionResetError, GeneratorExit):
             break

--- a/cli/medperf/web_ui/schemas.py
+++ b/cli/medperf/web_ui/schemas.py
@@ -21,7 +21,7 @@ class Notification(BaseModel):
         self.read = True
 
     def to_json(self):
-        return self.dict()
+        return self.model_dump()
 
 
 class EventBase(BaseModel):
@@ -29,7 +29,7 @@ class EventBase(BaseModel):
     task_id: Optional[str] = None
 
     def to_json(self):
-        return self.dict()
+        return self.model_dump()
 
 
 class Event(EventBase):
@@ -119,7 +119,7 @@ class WebUITask(BaseModel):
         self.running = running
 
     def to_json(self):
-        return self.dict()
+        return self.model_dump()
 
 
 class GlobalEventsManager:

--- a/cli/medperf/web_ui/static/js/common.js
+++ b/cli/medperf/web_ui/static/js/common.js
@@ -373,7 +373,7 @@ function onActionSuccess(panelTitle) {
                 url: url
             });
         } else {
-            showErrorModal("Something when wrong while " + panelTitle.toLowerCase(), response);
+            showErrorModal("Something went wrong while " + panelTitle.toLowerCase(), response);
         }
     };
 }

--- a/cli/pytest.ini
+++ b/cli/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+filterwarnings = ignore:color:UserWarning:yaspin

--- a/cli/pytest.ini
+++ b/cli/pytest.ini
@@ -1,2 +1,0 @@
-[pytest]
-filterwarnings = ignore:color:UserWarning:yaspin

--- a/cli/requirements.txt
+++ b/cli/requirements.txt
@@ -39,3 +39,4 @@ google-cloud-kms==3.11.0
 google-cloud-compute==1.46.0
 google-api-python-client==2.192.0
 tqdm==4.67.3
+python-multipart==0.0.32

--- a/cli/requirements.txt
+++ b/cli/requirements.txt
@@ -12,7 +12,7 @@ pytest-mock==3.14.0
 pyfakefs==5.8.0
 validators==0.18.2
 merge-args==0.1.5
-synapseclient==4.1.1
+synapseclient==4.12.0
 schema==0.7.5
 email-validator==2.0.0
 auth0-python==4.3.0

--- a/cli/requirements.txt
+++ b/cli/requirements.txt
@@ -1,9 +1,9 @@
-typer~=0.12.0
+typer~=0.15.0
 rich~=13.7.0
 PyYAML==6.0.1
 requests>=2.26.0
-pydantic==1.10.13
-yaspin==2.1.0
+pydantic==2.12.5
+yaspin==3.3.0
 tabulate==0.9.0
 pexpect==4.8.0
 colorama==0.4.4
@@ -23,8 +23,8 @@ GitPython==3.1.41
 psutil==5.9.8
 semver==3.0.4
 cookiecutter==2.1.1
-uvicorn==0.30.1
-fastapi==0.111.1
+uvicorn==0.37.0
+fastapi==0.116.1
 fastapi-login==1.10.2
 cryptography==46.0.3
 click==8.1.8


### PR DESCRIPTION
## What

  Upgrades the CLI from Pydantic v1 to v2 and adapts all entity schemas accordingly.

  - `validator` → `field_validator` (+ `@classmethod`, `mode="before"`)
  - `class Config` → `model_config = ConfigDict(use_enum_values=True)`
  - Explicit `= None` defaults on every `Optional` field (in v2 an `Optional` with no
    default is *required*), and `Optional[Status]` / `Optional[int]` for fields that
    defaulted to `None`
  - `.dict()` → `.model_dump()`, `.json()` → `.model_dump_json()`, `__fields__` → `model_fields`
  - New `TypeAdapter`-based `parse_datetime` replacing the removed `pydantic.datetime_parse`
  - Dependency bumps: pydantic 1.10→2.12, plus typer / yaspin / fastapi / uvicorn for compatibility
  - Fixes the yaspin 3.x "color … not a TTY" warning at the source (only request a
    spinner color when stdout is a TTY)

## Why

  Pydantic v2 is required by upcoming work; this isolates the framework migration into
  one reviewable, self-contained change.